### PR TITLE
Upgrade claude-code-action to v1

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       pull-requests: write
@@ -36,10 +37,9 @@ jobs:
           service_account: ${{ secrets.GC_SERVICE_ACCOUNT }}
 
       - name: Run Claude PR Action
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: "${{ secrets.GC_PROJECT_ID }}"
           CLOUD_ML_REGION: "asia-east1"
         with:
           use_vertex: "true"
-          timeout_minutes: "60"


### PR DESCRIPTION
Upgraded `anthropics/claude-code-action` to v1 following the migration guide.
Moved `timeout_minutes` to job-level configuration.
Verified configuration by reading the file.

---
*PR created automatically by Jules for task [16668535861129562379](https://jules.google.com/task/16668535861129562379) started by @MrOrz*