### PR TITLE
Fix Claude workflow permissions for branch creation

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write


### PR DESCRIPTION
Updated `.github/workflows/claude.yml` to include `contents: write` permission, fixing the issue where the Claude Code action failed to create branches.

---
*PR created automatically by Jules for task [16681383274081892980](https://jules.google.com/task/16681383274081892980) started by @MrOrz*