### PR TITLE
feat: Add Langfuse user feedback for ChatAgent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 
 # Browser-safe (public key only, VITE_ prefix exposes to Vite client bundle)
 VITE_LANGFUSE_PUBLIC_KEY=pk-lf-...
-VITE_LANGFUSE_BASE_URL=https://cloud.langfuse.com
+VITE_LANGFUSE_BASE_URL=https://langfuse.cofacts.tw

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+
+# Browser-safe (public key only, VITE_ prefix exposes to Vite client bundle)
+VITE_LANGFUSE_PUBLIC_KEY=pk-lf-...
+VITE_LANGFUSE_BASE_URL=https://cloud.langfuse.com

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,10 @@ jobs:
           SHA: ${{ github.sha }}
         run: |
           # Build frontend
-          docker build -t asia-east1-docker.pkg.dev/$PROJECT_ID/cofacts-ai/frontend:$SHA -f Dockerfile .
+          docker build \
+            --build-arg VITE_LANGFUSE_PUBLIC_KEY=${{ secrets.LANGFUSE_PUBLIC_KEY }} \
+            --build-arg VITE_LANGFUSE_BASE_URL="https://langfuse.cofacts.tw" \
+            -t asia-east1-docker.pkg.dev/$PROJECT_ID/cofacts-ai/frontend:$SHA -f Dockerfile .
           docker push asia-east1-docker.pkg.dev/$PROJECT_ID/cofacts-ai/frontend:$SHA
 
           # Build backend

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # Copy source and build
 COPY . .
+ARG VITE_LANGFUSE_PUBLIC_KEY
+ARG VITE_LANGFUSE_BASE_URL
 RUN pnpm run build
 
 # --- runtime ---

--- a/README.md
+++ b/README.md
@@ -33,13 +33,19 @@ pnpm install:agent
 > source adk/.venv/bin/activate
 > ```
 
-3. Set up environment variables for the ADK agent:
+3. Set up environment variables:
 
+For the ADK backend agent:
 ```bash
 cp adk/cofacts_ai/.env.example adk/cofacts_ai/.env
 ```
-
 Edit `adk/cofacts_ai/.env` and fill in the required values (at minimum `GOOGLE_API_KEY`).
+
+For the frontend UI (Vite / TanStack Start):
+```bash
+cp .env.example .env
+```
+Edit `.env` to configure your browser-safe variables (e.g. Langfuse keys).
 
 4. Start the development server:
 

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -26,7 +26,8 @@ from .tools import (
     submit_cofacts_reply,
     resolve_vertex_redirect
 )
-from .instrumentation import setup_instrumentation
+from google.adk.apps.app import App
+from .instrumentation import setup_instrumentation, LangfuseTracingPlugin
 
 load_dotenv()
 
@@ -545,5 +546,9 @@ ai_writer = LlmAgent(
     ],
 )
 
-root_agent = ai_writer
+root_agent = App(
+    name="cofacts_ai",
+    root_agent=ai_writer,
+    plugins=[LangfuseTracingPlugin()],
+)
 

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -546,7 +546,7 @@ ai_writer = LlmAgent(
     ],
 )
 
-root_agent = App(
+app = App(
     name="cofacts_ai",
     root_agent=ai_writer,
     plugins=[LangfuseTracingPlugin()],

--- a/adk/cofacts_ai/instrumentation.py
+++ b/adk/cofacts_ai/instrumentation.py
@@ -2,6 +2,9 @@ import os
 import logging
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
 from langfuse import get_client
+from google.adk.plugins.base_plugin import BasePlugin
+from google.adk.agents.invocation_context import InvocationContext
+from google.adk.events.event import Event
 
 logger = logging.getLogger(__name__)
 
@@ -20,3 +23,25 @@ def setup_instrumentation():
         logger.info("Langfuse instrumentation initialized.")
     else:
         logger.warning("Langfuse authentication failed. Skipping instrumentation.")
+
+
+class LangfuseTracingPlugin(BasePlugin):
+    """
+    ADK Plugin that stamps each emitted event with the current Langfuse
+    trace ID in custom_metadata, enabling the UI to submit user feedback
+    (thumbs up/down) against the correct Langfuse trace.
+    """
+
+    def __init__(self):
+        super().__init__(name="langfuse_tracing")
+
+    async def on_event_callback(
+        self, *, invocation_context: InvocationContext, event: Event
+    ):
+        langfuse = get_client()
+        trace_id = langfuse.get_current_trace_id()
+        if trace_id:
+            if event.custom_metadata is None:
+                event.custom_metadata = {}
+            event.custom_metadata["langfuse_trace_id"] = trace_id
+        return event

--- a/adk/cofacts_ai/instrumentation.py
+++ b/adk/cofacts_ai/instrumentation.py
@@ -28,8 +28,15 @@ def setup_instrumentation():
 class LangfuseTracingPlugin(BasePlugin):
     """
     ADK Plugin that stamps each emitted event with the current Langfuse
-    trace ID in custom_metadata, enabling the UI to submit user feedback
-    (thumbs up/down) against the correct Langfuse trace.
+    trace ID in custom_metadata.
+
+    We use `before_run_callback` and `run_config.custom_metadata` because:
+    1. ADK's `Runner` merges `run_config.custom_metadata` into every event
+       generated during the invocation.
+    2. This merging happens *before* the event is persisted to the session
+       store.
+    3. Using `on_event_callback` would be too late for persistence, as ADK
+       saves the event to the database before the plugin's `on_event` is called.
     """
 
     def __init__(self):
@@ -41,6 +48,8 @@ class LangfuseTracingPlugin(BasePlugin):
         langfuse = get_client()
         trace_id = langfuse.get_current_trace_id()
         if trace_id:
+            # Set the trace ID in run_config so ADK automatically stamps all
+            # future events in this invocation before they are saved to the DB.
             if invocation_context.run_config.custom_metadata is None:
                 invocation_context.run_config.custom_metadata = {}
             invocation_context.run_config.custom_metadata["langfuse_trace_id"] = trace_id

--- a/adk/cofacts_ai/instrumentation.py
+++ b/adk/cofacts_ai/instrumentation.py
@@ -35,13 +35,13 @@ class LangfuseTracingPlugin(BasePlugin):
     def __init__(self):
         super().__init__(name="langfuse_tracing")
 
-    async def on_event_callback(
-        self, *, invocation_context: InvocationContext, event: Event
+    async def before_run_callback(
+        self, *, invocation_context: InvocationContext
     ):
         langfuse = get_client()
         trace_id = langfuse.get_current_trace_id()
         if trace_id:
-            if event.custom_metadata is None:
-                event.custom_metadata = {}
-            event.custom_metadata["langfuse_trace_id"] = trace_id
-        return event
+            if invocation_context.run_config.custom_metadata is None:
+                invocation_context.run_config.custom_metadata = {}
+            invocation_context.run_config.custom_metadata["langfuse_trace_id"] = trace_id
+        return None

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@tanstack/router-plugin": "^1.132.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "langfuse": "^3.38.20",
     "lucide-react": "^0.574.0",
     "nitro": "latest",
     "openapi-fetch": "^0.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      langfuse:
+        specifier: ^3.38.20
+        version: 3.38.20
       lucide-react:
         specifier: ^0.574.0
         version: 0.574.0(react@19.2.4)
@@ -784,48 +787,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-arm64-musl@0.110.0':
     resolution: {integrity: sha512-53GjCVY8kvymk9P6qNDh6zyblcehF5QHstq9QgCjv13ONGRnSHjeds0PxIwiihD7h295bxsWs84DN39syLPH4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-linux-ppc64-gnu@0.110.0':
     resolution: {integrity: sha512-li8XcN81dxbJDMBESnTgGhoiAQ+CNIdM0QGscZ4duVPjCry1RpX+5FJySFbGqG3pk4s9ZzlL/vtQtbRzZIZOzg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-gnu@0.110.0':
     resolution: {integrity: sha512-SweKfsnLKShu6UFV8mwuj1d1wmlNoL/FlAxPUzwjEBgwiT2HQkY24KnjBH+TIA+//1O83kzmWKvvs4OuEhdIEQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-musl@0.110.0':
     resolution: {integrity: sha512-oH8G4aFMP8XyTsEpdANC5PQyHgSeGlopHZuW1rpyYcaErg5YaK0vXjQ4EM5HVvPm+feBV24JjxgakTnZoF3aOQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-linux-s390x-gnu@0.110.0':
     resolution: {integrity: sha512-W9na+Vza7XVUlpf8wMt4QBfH35KeTENEmnpPUq3NSlbQHz8lSlSvhAafvo43NcKvHAXV3ckD/mUf2VkqSdbklg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-gnu@0.110.0':
     resolution: {integrity: sha512-XJdA4mmmXOjJxSRgNJXsDP7Xe8h3gQhmb56hUcCrvq5d+h5UcEi2pR8rxsdIrS8QmkLuBA3eHkGK8E27D7DTgQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-musl@0.110.0':
     resolution: {integrity: sha512-QqzvALuOTtSckI8x467R4GNArzYDb/yEh6aNzLoeaY1O7vfT7SPDwlOEcchaTznutpeS9Dy8gUS/AfqtUHaufw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-openharmony-arm64@0.110.0':
     resolution: {integrity: sha512-gAMssLs2Q3+uhLZxanh1DF+27Kaug3cf4PXb9AB7XK81DR+LVcKySXaoGYoOs20Co0fFSphd6rRzKge2qDK3dA==}
@@ -903,48 +914,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-arm64-musl@0.110.0':
     resolution: {integrity: sha512-e5JN94/oy+wevk76q+LMr+2klTTcO60uXa+Wkq558Ms7mdF2TvkKFI++d/JeiuIwJLTi/BxQ4qdT5FWcsHM/ug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-ppc64-gnu@0.110.0':
     resolution: {integrity: sha512-Y3/Tnnz1GvDpmv8FXBIKtdZPsdZklOEPdrL6NHrN5i2u54BOkybFaDSptgWF53wOrJlTrcmAVSE6fRKK9XCM2Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-riscv64-gnu@0.110.0':
     resolution: {integrity: sha512-Y0E35iA9/v9jlkNcP6tMJ+ZFOS0rLsWDqG6rU9z+X2R3fBFJBO9UARIK6ngx8upxk81y1TFR2CmBFhupfYdH6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-riscv64-musl@0.110.0':
     resolution: {integrity: sha512-JOUSYFfHjBUs7xp2FHmZHb8eTYD/oEu0NklS6JgUauqnoXZHiTLPLVW2o2uVCqldnabYHcomuwI2iqVFYJNhTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-s390x-gnu@0.110.0':
     resolution: {integrity: sha512-7blgoXF9D3Ngzb7eun23pNrHJpoV/TtE6LObwlZ3Nmb4oZ6Z+yMvBVaoW68NarbmvNGfZ95zrOjgm6cVETLYBA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-gnu@0.110.0':
     resolution: {integrity: sha512-YQ2joGWCVDZVEU2cD/r/w49hVjDm/Qu1BvC/7zs8LvprzdLS/HyMXGF2oA0puw0b+AqgYaz3bhwKB2xexHyITQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-musl@0.110.0':
     resolution: {integrity: sha512-fkjr5qE632ULmNgvFXWDR/8668WxERz3tU7TQFp6JebPBneColitjSkdx6VKNVXEoMmQnOvBIGeP5tUNT384oA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-openharmony-arm64@0.110.0':
     resolution: {integrity: sha512-HWH9Zj+lMrdSTqFRCZsvDWMz7OnMjbdGsm3xURXWfRZpuaz0bVvyuZNDQXc4FyyhRDsemICaJbU1bgeIpUJDGw==}
@@ -1025,66 +1044,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -1197,24 +1229,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.0':
     resolution: {integrity: sha512-XKcSStleEVnbH6W/9DHzZv1YhjE4eSS6zOu2eRtYAIh7aV4o3vIBs+t/B15xlqoxt6ef/0uiqJVB6hkHjWD/0A==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.0':
     resolution: {integrity: sha512-/hlXCBqn9K6fi7eAM0RsobHwJYa5V/xzWspVTzxnX+Ft9v6n+30Pz8+RxCn7sQL/vRHHLS30iQPrHQunu6/vJA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.0':
     resolution: {integrity: sha512-lKUaygq4G7sWkhQbfdRRBkaq4LY39IriqBQ+Gk6l5nKq6Ay2M2ZZb1tlIyRNgZKS8cbErTwuYSor0IIULC0SHw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.0':
     resolution: {integrity: sha512-xuDjhAsFdUuFP5W9Ze4k/o4AskUtI8bcAGU4puTYprr89QaYFmhYOPfP+d1pH+k9ets6RoE23BXZM1X1jJqoyw==}
@@ -1658,41 +1694,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2875,6 +2919,14 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
+  langfuse-core@3.38.20:
+    resolution: {integrity: sha512-zBKVmQN/1oT5VWZUBYlWzvokIlkC/6mnpgr/2atMyTeAm+jR3ia7w2iJMjlrF5/oG8ukO1s8+LDRCzJpF1QeEA==}
+    engines: {node: '>=18'}
+
+  langfuse@3.38.20:
+    resolution: {integrity: sha512-MAmBAASSzJtmK1O9HQegA1mFsQhT8Yf+OJRGvE7FXkyv3g/eiBE0glLD0Ohg3pkxhoPdggM5SejK7ue9ctlaMA==}
+    engines: {node: '>=18'}
+
   launch-editor@2.13.0:
     resolution: {integrity: sha512-u+9asUHMJ99lA15VRMXw5XKfySFR9dGXwgsgS14YTbUq3GITP58mIM32At90P5fZ+MUId5Yw+IwI/yKub7jnCQ==}
 
@@ -2917,24 +2969,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -3195,6 +3251,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
 
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
@@ -7027,6 +7087,14 @@ snapshots:
 
   kleur@4.1.5: {}
 
+  langfuse-core@3.38.20:
+    dependencies:
+      mustache: 4.2.0
+
+  langfuse@3.38.20:
+    dependencies:
+      langfuse-core: 3.38.20
+
   launch-editor@2.13.0:
     dependencies:
       picocolors: 1.1.1
@@ -7536,6 +7604,8 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
+
+  mustache@4.2.0: {}
 
   mute-stream@2.0.0: {}
 

--- a/src/components/AgentMessage.tsx
+++ b/src/components/AgentMessage.tsx
@@ -4,29 +4,32 @@ import type { ChatMessage } from '@/lib/adk'
 
 interface AgentMessageProps {
   message: ChatMessage
+  showAvatar?: boolean
 }
 
-export function AgentMessage({ message }: AgentMessageProps) {
+export function AgentMessage({ message, showAvatar = true }: AgentMessageProps) {
   return (
     <div className="flex flex-col items-start w-full">
       {/* Agent header */}
-      <div className="flex items-center gap-2 mb-2 md:mb-3">
-        <div className="w-6 h-6 rounded-full bg-primary/20 flex items-center justify-center">
-          <span className="material-symbols-outlined text-sm text-yellow-700">
-            smart_toy
+      {showAvatar && (
+        <div className="flex items-center gap-2 mb-2 md:mb-3">
+          <div className="w-6 h-6 rounded-full bg-primary/20 flex items-center justify-center">
+            <span className="material-symbols-outlined text-sm text-yellow-700">
+              smart_toy
+            </span>
+          </div>
+          <span className="text-sm font-semibold text-gray-900">
+            {message.author === 'investigator'
+              ? 'AI Investigator'
+              : message.author === 'verifier'
+                ? 'AI Verifier'
+                : 'Cofacts AI Agent'}
           </span>
         </div>
-        <span className="text-sm font-semibold text-gray-900">
-          {message.author === 'investigator'
-            ? 'AI Investigator'
-            : message.author === 'verifier'
-              ? 'AI Verifier'
-              : 'Cofacts AI Agent'}
-        </span>
-      </div>
+      )}
 
       {/* Message content */}
-      <div className="w-full text-text-main leading-7 text-sm max-w-none space-y-4">
+      <div className="w-full text-text-main leading-7 text-sm max-w-none space-y-2">
         {message.parts?.map((part, i) => {
           if (part.text) {
             return (

--- a/src/components/AgentMessage.tsx
+++ b/src/components/AgentMessage.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import type { ChatMessage } from '@/lib/adk'
+import { LangfuseWeb } from 'langfuse'
 
 interface AgentMessageProps {
   message: ChatMessage
@@ -9,6 +10,31 @@ interface AgentMessageProps {
 
 export function AgentMessage({ message }: AgentMessageProps) {
   const [feedbackGiven, setFeedbackGiven] = useState<'up' | 'down' | null>(null)
+
+  const langfuse = useMemo(
+    () =>
+      import.meta.env.VITE_LANGFUSE_PUBLIC_KEY
+        ? new LangfuseWeb({
+            publicKey: import.meta.env.VITE_LANGFUSE_PUBLIC_KEY,
+            baseUrl: import.meta.env.VITE_LANGFUSE_BASE_URL,
+          })
+        : null,
+    [],
+  )
+
+  const handleFeedback = (value: 'up' | 'down') => {
+    const next = feedbackGiven === value ? null : value
+    setFeedbackGiven(next)
+
+    if (langfuse && message.langfuseTraceId && next !== null) {
+      langfuse.score({
+        traceId: message.langfuseTraceId,
+        name: 'user-thumbs',
+        value: next === 'up' ? 1 : 0,
+        dataType: 'BOOLEAN',
+      })
+    }
+  }
 
   const fullText = useMemo(() => {
     return message.parts
@@ -80,9 +106,7 @@ export function AgentMessage({ message }: AgentMessageProps) {
       {!message.isStreaming && fullText && (
         <div className="flex items-center gap-3 pt-2 mt-4 border-t border-gray-100 w-full">
           <button
-            onClick={() =>
-              setFeedbackGiven(feedbackGiven === 'up' ? null : 'up')
-            }
+            onClick={() => handleFeedback('up')}
             className={`p-1 rounded hover:bg-gray-100 transition-colors ${feedbackGiven === 'up'
               ? 'text-primary'
               : 'text-gray-400 hover:text-gray-600'
@@ -93,9 +117,7 @@ export function AgentMessage({ message }: AgentMessageProps) {
             </span>
           </button>
           <button
-            onClick={() =>
-              setFeedbackGiven(feedbackGiven === 'down' ? null : 'down')
-            }
+            onClick={() => handleFeedback('down')}
             className={`p-1 rounded hover:bg-gray-100 transition-colors ${feedbackGiven === 'down'
               ? 'text-destructive'
               : 'text-gray-400 hover:text-gray-600'

--- a/src/components/AgentMessage.tsx
+++ b/src/components/AgentMessage.tsx
@@ -16,9 +16,9 @@ const langfuse = import.meta.env.VITE_LANGFUSE_PUBLIC_KEY
   : null
 
 export function AgentMessage({ message }: AgentMessageProps) {
-  const [feedbackGiven, setFeedbackGiven] = useState<'up' | 'down' | null>(null)
+  const [feedbackGiven, setFeedbackGiven] = useState<1 | -1 | null>(null)
 
-  const handleFeedback = (value: 'up' | 'down') => {
+  const handleFeedback = (value: 1 | -1) => {
     const next = feedbackGiven === value ? null : value
     setFeedbackGiven(next)
 
@@ -26,8 +26,8 @@ export function AgentMessage({ message }: AgentMessageProps) {
       langfuse.score({
         traceId: message.langfuseTraceId,
         name: 'user-thumbs',
-        value: next === 'up' ? 1 : 0,
-        dataType: 'BOOLEAN',
+        value: next,
+        dataType: 'NUMERIC',
       })
     }
   }
@@ -102,8 +102,8 @@ export function AgentMessage({ message }: AgentMessageProps) {
       {!message.isStreaming && fullText && (
         <div className="flex items-center gap-3 pt-2 mt-4 border-t border-gray-100 w-full">
           <button
-            onClick={() => handleFeedback('up')}
-            className={`p-1 rounded hover:bg-gray-100 transition-colors ${feedbackGiven === 'up'
+            onClick={() => handleFeedback(1)}
+            className={`p-1 rounded hover:bg-gray-100 transition-colors ${feedbackGiven === 1
               ? 'text-primary'
               : 'text-gray-400 hover:text-gray-600'
               }`}
@@ -113,8 +113,8 @@ export function AgentMessage({ message }: AgentMessageProps) {
             </span>
           </button>
           <button
-            onClick={() => handleFeedback('down')}
-            className={`p-1 rounded hover:bg-gray-100 transition-colors ${feedbackGiven === 'down'
+            onClick={() => handleFeedback(-1)}
+            className={`p-1 rounded hover:bg-gray-100 transition-colors ${feedbackGiven === -1
               ? 'text-destructive'
               : 'text-gray-400 hover:text-gray-600'
               }`}

--- a/src/components/AgentMessage.tsx
+++ b/src/components/AgentMessage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import type { ChatMessage } from '@/lib/adk'
@@ -31,13 +31,6 @@ export function AgentMessage({ message }: AgentMessageProps) {
       })
     }
   }
-
-  const fullText = useMemo(() => {
-    return message.parts
-      ?.map((p) => p.text ?? '')
-      .filter(Boolean)
-      .join('\n')
-  }, [message.parts])
 
   return (
     <div className="flex flex-col items-start w-full">
@@ -99,7 +92,7 @@ export function AgentMessage({ message }: AgentMessageProps) {
       </div>
 
       {/* Feedback buttons (only show when not streaming) */}
-      {!message.isStreaming && fullText && (
+      {!message.isStreaming && (
         <div className="flex items-center gap-3 pt-2 mt-4 border-t border-gray-100 w-full">
           {message.langfuseTraceId !== undefined && (
             <>
@@ -128,7 +121,13 @@ export function AgentMessage({ message }: AgentMessageProps) {
             </>
           )}
           <button
-            onClick={() => navigator.clipboard.writeText(fullText)}
+            onClick={() => {
+              const textToCopy = message.parts
+                ?.map((p) => p.text ?? '')
+                .filter(Boolean)
+                .join('\n') ?? ''
+              navigator.clipboard.writeText(textToCopy)
+            }}
             className="text-gray-400 hover:text-gray-600 transition-colors p-1 rounded hover:bg-gray-100 ml-auto"
           >
             <span className="material-symbols-outlined text-[18px]">

--- a/src/components/AgentMessage.tsx
+++ b/src/components/AgentMessage.tsx
@@ -1,37 +1,12 @@
-import { useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import type { ChatMessage } from '@/lib/adk'
-import { LangfuseWeb } from 'langfuse'
 
 interface AgentMessageProps {
   message: ChatMessage
 }
 
-const langfuse = import.meta.env.VITE_LANGFUSE_PUBLIC_KEY
-  ? new LangfuseWeb({
-    publicKey: import.meta.env.VITE_LANGFUSE_PUBLIC_KEY,
-    baseUrl: import.meta.env.VITE_LANGFUSE_BASE_URL,
-  })
-  : null
-
 export function AgentMessage({ message }: AgentMessageProps) {
-  const [feedbackGiven, setFeedbackGiven] = useState<1 | -1 | null>(null)
-
-  const handleFeedback = (value: 1 | -1) => {
-    const next = feedbackGiven === value ? null : value
-    setFeedbackGiven(next)
-
-    if (langfuse && message.langfuseTraceId && next !== null) {
-      langfuse.score({
-        traceId: message.langfuseTraceId,
-        name: 'user-thumbs',
-        value: next,
-        dataType: 'NUMERIC',
-      })
-    }
-  }
-
   return (
     <div className="flex flex-col items-start w-full">
       {/* Agent header */}
@@ -90,52 +65,6 @@ export function AgentMessage({ message }: AgentMessageProps) {
           return null
         })}
       </div>
-
-      {/* Feedback buttons (only show when not streaming) */}
-      {!message.isStreaming && (
-        <div className="flex items-center gap-3 pt-2 mt-4 border-t border-gray-100 w-full">
-          {message.langfuseTraceId !== undefined && (
-            <>
-              <button
-                onClick={() => handleFeedback(1)}
-                className={`p-1 rounded hover:bg-gray-100 transition-colors ${feedbackGiven === 1
-                  ? 'text-primary'
-                  : 'text-gray-400 hover:text-gray-600'
-                  }`}
-              >
-                <span className="material-symbols-outlined text-[18px]">
-                  thumb_up
-                </span>
-              </button>
-              <button
-                onClick={() => handleFeedback(-1)}
-                className={`p-1 rounded hover:bg-gray-100 transition-colors ${feedbackGiven === -1
-                  ? 'text-destructive'
-                  : 'text-gray-400 hover:text-gray-600'
-                  }`}
-              >
-                <span className="material-symbols-outlined text-[18px]">
-                  thumb_down
-                </span>
-              </button>
-            </>
-          )}
-          <button
-            onClick={() => {
-              const textToCopy = message.parts
-                ?.map((p) => p.text ?? '')
-                .filter(Boolean)
-                .join('\n') ?? ''
-              navigator.clipboard.writeText(textToCopy)
-            }}
-            className="text-gray-400 hover:text-gray-600 transition-colors p-1 rounded hover:bg-gray-100 ml-auto"
-          >
-            <span className="material-symbols-outlined text-[18px]">
-              content_copy
-            </span>
-          </button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/components/AgentMessage.tsx
+++ b/src/components/AgentMessage.tsx
@@ -8,19 +8,15 @@ interface AgentMessageProps {
   message: ChatMessage
 }
 
+const langfuse = import.meta.env.VITE_LANGFUSE_PUBLIC_KEY
+  ? new LangfuseWeb({
+      publicKey: import.meta.env.VITE_LANGFUSE_PUBLIC_KEY,
+      baseUrl: import.meta.env.VITE_LANGFUSE_BASE_URL,
+    })
+  : null
+
 export function AgentMessage({ message }: AgentMessageProps) {
   const [feedbackGiven, setFeedbackGiven] = useState<'up' | 'down' | null>(null)
-
-  const langfuse = useMemo(
-    () =>
-      import.meta.env.VITE_LANGFUSE_PUBLIC_KEY
-        ? new LangfuseWeb({
-            publicKey: import.meta.env.VITE_LANGFUSE_PUBLIC_KEY,
-            baseUrl: import.meta.env.VITE_LANGFUSE_BASE_URL,
-          })
-        : null,
-    [],
-  )
 
   const handleFeedback = (value: 'up' | 'down') => {
     const next = feedbackGiven === value ? null : value

--- a/src/components/AgentMessage.tsx
+++ b/src/components/AgentMessage.tsx
@@ -10,9 +10,9 @@ interface AgentMessageProps {
 
 const langfuse = import.meta.env.VITE_LANGFUSE_PUBLIC_KEY
   ? new LangfuseWeb({
-      publicKey: import.meta.env.VITE_LANGFUSE_PUBLIC_KEY,
-      baseUrl: import.meta.env.VITE_LANGFUSE_BASE_URL,
-    })
+    publicKey: import.meta.env.VITE_LANGFUSE_PUBLIC_KEY,
+    baseUrl: import.meta.env.VITE_LANGFUSE_BASE_URL,
+  })
   : null
 
 export function AgentMessage({ message }: AgentMessageProps) {
@@ -101,28 +101,32 @@ export function AgentMessage({ message }: AgentMessageProps) {
       {/* Feedback buttons (only show when not streaming) */}
       {!message.isStreaming && fullText && (
         <div className="flex items-center gap-3 pt-2 mt-4 border-t border-gray-100 w-full">
-          <button
-            onClick={() => handleFeedback(1)}
-            className={`p-1 rounded hover:bg-gray-100 transition-colors ${feedbackGiven === 1
-              ? 'text-primary'
-              : 'text-gray-400 hover:text-gray-600'
-              }`}
-          >
-            <span className="material-symbols-outlined text-[18px]">
-              thumb_up
-            </span>
-          </button>
-          <button
-            onClick={() => handleFeedback(-1)}
-            className={`p-1 rounded hover:bg-gray-100 transition-colors ${feedbackGiven === -1
-              ? 'text-destructive'
-              : 'text-gray-400 hover:text-gray-600'
-              }`}
-          >
-            <span className="material-symbols-outlined text-[18px]">
-              thumb_down
-            </span>
-          </button>
+          {message.langfuseTraceId !== undefined && (
+            <>
+              <button
+                onClick={() => handleFeedback(1)}
+                className={`p-1 rounded hover:bg-gray-100 transition-colors ${feedbackGiven === 1
+                  ? 'text-primary'
+                  : 'text-gray-400 hover:text-gray-600'
+                  }`}
+              >
+                <span className="material-symbols-outlined text-[18px]">
+                  thumb_up
+                </span>
+              </button>
+              <button
+                onClick={() => handleFeedback(-1)}
+                className={`p-1 rounded hover:bg-gray-100 transition-colors ${feedbackGiven === -1
+                  ? 'text-destructive'
+                  : 'text-gray-400 hover:text-gray-600'
+                  }`}
+              >
+                <span className="material-symbols-outlined text-[18px]">
+                  thumb_down
+                </span>
+              </button>
+            </>
+          )}
           <button
             onClick={() => navigator.clipboard.writeText(fullText)}
             className="text-gray-400 hover:text-gray-600 transition-colors p-1 rounded hover:bg-gray-100 ml-auto"

--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -59,7 +59,7 @@ export function ChatArea({
         })}
 
         {
-          isStreaming && <p className="flex items-center gap-2 text-gray-500">
+          isStreaming && <p className="flex items-center gap-2 text-gray-500 mt-2">
             正在思考中
             <span className="typing-indicator ml-1">
               <span />

--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -31,15 +31,19 @@ export function ChatArea({
       {/* Messages area */}
       <div
         ref={scrollRef}
-        className="flex-1 overflow-y-auto p-4 md:p-6 space-y-6 md:space-y-8 chat-container pb-0"
+        className="flex-1 overflow-y-auto p-4 md:p-6 chat-container pb-0"
       >
         {messages.map((msg, index) => {
+          const prevMsg: ChatMessage | undefined = messages[index - 1];
           const nextMsg: ChatMessage | undefined = messages[index + 1];
 
           return <React.Fragment key={msg.id}>
             {msg.author === 'user'
               ? <UserMessage message={msg} />
-              : <AgentMessage message={msg} />}
+              : <AgentMessage
+                message={msg}
+                showAvatar={msg.author !== prevMsg?.author}
+              />}
             {
               /* Show thumbs up/down when all below are true:
                 - Message has trace id

--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react'
+import React from 'react'
 import { UserMessage } from './UserMessage'
 import { AgentMessage } from './AgentMessage'
+import { FeedbackButtons } from './FeedbackButtons'
 import { ChatInput } from './ChatInput'
 import type { ChatMessage } from '@/lib/adk'
 
@@ -31,29 +33,25 @@ export function ChatArea({
         ref={scrollRef}
         className="flex-1 overflow-y-auto p-4 md:p-6 space-y-6 md:space-y-8 chat-container pb-0"
       >
-        {/* Date separator */}
-        {messages.length > 0 && (
-          <div className="flex justify-center">
-            <span className="text-xs text-text-muted bg-gray-100 px-3 py-1 rounded-full">
-              {new Date().toLocaleDateString('zh-TW', {
-                month: 'long',
-                day: 'numeric',
-              })}{' '}
-              {new Date().toLocaleTimeString('zh-TW', {
-                hour: '2-digit',
-                minute: '2-digit',
-              })}
-            </span>
-          </div>
-        )}
+        {messages.map((msg, index) => {
+          const nextMsg: ChatMessage | undefined = messages[index + 1];
 
-        {messages.map((msg) => {
-          if (msg.role === 'user') {
-            return msg.author === 'user'
-              ? <UserMessage key={msg.id} message={msg} />
-              : null // function response, or anything else; render nothing
-          }
-          return <AgentMessage key={msg.id} message={msg} />
+          return <React.Fragment key={msg.id}>
+            {msg.author === 'user'
+              ? <UserMessage message={msg} />
+              : <AgentMessage message={msg} />}
+            {
+              /* Show thumbs up/down when all below are true:
+                - Message has trace id
+                - Message is not streaming
+                - Next message has different trace id or doesn't exist
+              */
+              msg.langfuseTraceId &&
+              !isStreaming &&
+              (!nextMsg?.langfuseTraceId || msg.langfuseTraceId !== nextMsg.langfuseTraceId) &&
+              <FeedbackButtons traceId={msg.langfuseTraceId} />
+            }
+          </React.Fragment>
         })}
 
         {

--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -51,7 +51,7 @@ export function ChatArea({
                 - Next message has different trace id or doesn't exist
               */
               msg.langfuseTraceId &&
-              !isStreaming &&
+              !msg.isStreaming &&
               (!nextMsg?.langfuseTraceId || msg.langfuseTraceId !== nextMsg.langfuseTraceId) &&
               <FeedbackButtons traceId={msg.langfuseTraceId} />
             }

--- a/src/components/FeedbackButtons.tsx
+++ b/src/components/FeedbackButtons.tsx
@@ -21,6 +21,7 @@ export function FeedbackButtons({ traceId }: FeedbackButtonsProps) {
 
     if (langfuse && next !== null) {
       langfuse.score({
+        id: `user-${traceId}`,
         traceId,
         name: 'user-thumbs',
         value: next,

--- a/src/components/FeedbackButtons.tsx
+++ b/src/components/FeedbackButtons.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react'
+import { LangfuseWeb } from 'langfuse'
+
+const langfuse = import.meta.env.VITE_LANGFUSE_PUBLIC_KEY
+  ? new LangfuseWeb({
+    publicKey: import.meta.env.VITE_LANGFUSE_PUBLIC_KEY,
+    baseUrl: import.meta.env.VITE_LANGFUSE_BASE_URL,
+  })
+  : null
+
+interface FeedbackButtonsProps {
+  traceId: string
+}
+
+export function FeedbackButtons({ traceId }: FeedbackButtonsProps) {
+  const [feedbackGiven, setFeedbackGiven] = useState<1 | -1 | null>(null)
+
+  const handleFeedback = (value: 1 | -1) => {
+    const next = feedbackGiven === value ? null : value
+    setFeedbackGiven(next)
+
+    if (langfuse && next !== null) {
+      langfuse.score({
+        traceId,
+        name: 'user-thumbs',
+        value: next,
+        dataType: 'NUMERIC',
+      })
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-3 pt-2 mt-4 border-t border-gray-100 w-full">
+      <button
+        onClick={() => handleFeedback(1)}
+        className={`p-1 rounded hover:bg-gray-100 transition-colors ${feedbackGiven === 1
+          ? 'text-primary'
+          : 'text-gray-400 hover:text-gray-600'
+          }`}
+      >
+        <span className="material-symbols-outlined text-[18px]">
+          thumb_up
+        </span>
+      </button>
+      <button
+        onClick={() => handleFeedback(-1)}
+        className={`p-1 rounded hover:bg-gray-100 transition-colors ${feedbackGiven === -1
+          ? 'text-destructive'
+          : 'text-gray-400 hover:text-gray-600'
+          }`}
+      >
+        <span className="material-symbols-outlined text-[18px]">
+          thumb_down
+        </span>
+      </button>
+    </div>
+  )
+}

--- a/src/lib/adk.ts
+++ b/src/lib/adk.ts
@@ -27,6 +27,7 @@ export interface ChatMessage extends AdkContent {
   author?: string
   isStreaming?: boolean
   timestamp?: Date
+  langfuseTraceId?: string
 }
 
 export interface SourceItem {

--- a/src/lib/chatCache.ts
+++ b/src/lib/chatCache.ts
@@ -164,10 +164,15 @@ export function applyEventToState(
 
   // console.info('applyEventToState', event);
 
-  const eventParts = event.content.parts
+  // Skip function responses
+  const eventParts = event.content.parts.filter(p => !p.functionResponse);
 
-  // event is user message, just append message
   if (event.content.role === 'user') {
+    // Don't insert user message if it's just a function response.
+    // We may store the map of function response as a separate map when we need tool response in UI.
+    if (eventParts.length === 0) return prev;
+
+    // event is user message, just append message
     return {
       ...prev, messages: [
         ...prev.messages,

--- a/src/lib/chatCache.ts
+++ b/src/lib/chatCache.ts
@@ -201,6 +201,7 @@ export function applyEventToState(
           parts: [...eventParts],
           isStreaming: event.partial !== false,
           timestamp: new Date(),
+          langfuseTraceId: event.customMetadata?.['langfuse_trace_id'] as string | undefined,
         },
       ]
     } else if (!event.partial) {


### PR DESCRIPTION
## Goal
Improve the user feedback experience by ensuring feedback buttons are correctly associated with model traces and cleaning up the chat UI for better readability.

https://github.com/user-attachments/assets/d3d0c765-15d5-483a-86c9-dd59843028f3

## Technical Choices & Rationale

### 1. Centralized Feedback Logic in `ChatArea`
*   **Change**: Moved `FeedbackButtons` from individual `AgentMessage` components into the `ChatArea` rendering loop.
*   **Rationale**: Feedback in Langfuse is tied to a **Trace ID**, which can span multiple message bubbles (e.g., when the assistant uses tools or sends multiple parts). By moving the logic to `ChatArea`, we can:
    *   Compare `langfuseTraceId` between consecutive messages.
    *   Only render feedback buttons when a trace sequence ends (i.e., when the next message has a different trace ID or is from the user).
    *   Prevent redundant feedback buttons when multiple assistant messages belong to the same logical response.

### 2. Message State & Internal Filtering
*   **Change**: Modified `applyEventToState` to filter out `functionResponse` parts and store `langfuseTraceId` directly in the message object.
*   **Rationale**: 
    *   **Internal State**: `functionResponse` messages are used for agent orchestration and do not contribute to the user-facing UI. Removing them from the `messages` array prevents "empty" bubbles and ensures message index-based logic (like feedback placement) remains accurate.
    *   **Trace Tracking**: Storing the trace ID at the message level allows the frontend to correctly identify which trace to submit feedback for, even after page reloads.

### 3. UI Consolidation for Consecutive Messages
*   **Change**: Added a `showAvatar` prop to `AgentMessage` and implemented logic in `ChatArea` to only show the header (Avatar + Agent Name) for the first message in a consecutive sequence.
*   **Rationale**: Reduces visual noise and vertical scrolling. When the assistant sends multiple messages, it now appears as a single continuous conversation block rather than multiple disconnected bubbles.

### 4. Numeric Feedback Scores
*   **Change**: Updated the feedback mechanism to use numeric values (`+1` for Thumbs Up, `-1` for Thumbs Down) instead of booleans.
*   **Rationale**: Aligns with Langfuse's standard scoring system, making it easier to aggregate and analyze feedback in the dashboard.

## Verification Results
*   Verified that feedback buttons only appear at the end of an assistant's response group.
*   Verified that consecutive assistant messages are grouped visually.
*   Confirmed that clicking Thumbs Up/Down sends the correct `+1` or `-1` score to the associated Langfuse trace ID.
*   Checked that tool/function responses are no longer creating empty space in the chat history.

---
*Co-authored-by: Antigravity <antigravity@google.com>*
