### PR TITLE
ci: delete GitHub environment upon PR preview cleanup

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -30,29 +30,15 @@ jobs:
             --region asia-east1 \
             --remove-tags="pr-${{ github.event.number }}" || echo "Tag not found or service does not exist, skipping."
 
-      - name: Deactivate GitHub Deployment
+      - name: Delete GitHub Environment
         uses: actions/github-script@v7
         with:
           script: |
-            const environment = `pr-${context.issue.number}`;
+            const environment_name = `pr-${context.issue.number}`;
             const { owner, repo } = context.repo;
 
-            try {
-              const deployments = await github.rest.repos.listDeployments({
-                owner,
-                repo,
-                environment,
-              });
-
-              for (const deployment of deployments.data) {
-                await github.rest.repos.createDeploymentStatus({
-                  owner,
-                  repo,
-                  deployment_id: deployment.id,
-                  state: 'inactive',
-                  description: 'Preview environment deactivated.',
-                });
-              }
-            } catch (error) {
-              console.error('Error deactivating deployments:', error);
-            }
+            await github.rest.repos.deleteAnEnvironment({
+              owner,
+              repo,
+              environment_name,
+            });


### PR DESCRIPTION
Currently, the `.github/workflows/preview-cleanup.yml` workflow sets the GitHub deployment to 'inactive' when a PR is closed. This causes preview environments (e.g., `pr-123`) to accumulate indefinitely in the repository's environments settings page.

This updates the GitHub Action script to explicitly delete the environment using `github.rest.repos.deleteAnEnvironment`. Deleting the environment automatically cleans up the repository settings. The `try...catch` block was removed so that any errors directly fail the action step, as requested.

---
*PR created automatically by Jules for task [392506522579631310](https://jules.google.com/task/392506522579631310) started by @MrOrz*