### PR TITLE
Fix Langfuse environment variables in CD workflow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -56,3 +56,6 @@ jobs:
           tags: cofacts/site:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            VITE_LANGFUSE_PUBLIC_KEY=${{ secrets.LANGFUSE_PUBLIC_KEY }}
+            VITE_LANGFUSE_BASE_URL=https://langfuse.cofacts.tw


### PR DESCRIPTION
This submission fixes an issue where Langfuse feedback features were not working in production deployments due to missing environment variables during the Docker build process in `cd.yaml`. I added `VITE_LANGFUSE_PUBLIC_KEY` and `VITE_LANGFUSE_BASE_URL` as build arguments, matching the configuration in `deploy.yml`. Tests were run to ensure no regressions.

---
*PR created automatically by Jules for task [12496008462108166446](https://jules.google.com/task/12496008462108166446) started by @MrOrz*