### PR TITLE
Hide mock right side panel and mobile FAB

### DIFF
--- a/src/components/RightDrawer.tsx
+++ b/src/components/RightDrawer.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { ResponseEditor } from './ResponseEditor'
 import { SourceLinkage } from './SourceLinkage'
-import type { DrawerTab } from '@/routes/_app'
 import type { SourceItem } from '@/lib/adk'
+
+export type DrawerTab = 'editor' | 'sources'
 
 interface RightDrawerProps {
   isOpen: boolean

--- a/src/routes/_app.tsx
+++ b/src/routes/_app.tsx
@@ -1,19 +1,14 @@
 import { Outlet, createFileRoute } from '@tanstack/react-router'
 import { useCallback, useState } from 'react'
 import { Sidebar } from '@/components/Sidebar'
-import { RightDrawer } from '@/components/RightDrawer'
 import { Header } from '@/components/Header'
 
 export const Route = createFileRoute('/_app')({
   component: AppLayout,
 })
 
-export type DrawerTab = 'editor' | 'sources'
-
 function AppLayout() {
   const [sidebarOpen, setSidebarOpen] = useState(false)
-  const [drawerOpen, setDrawerOpen] = useState(false)
-  const [activeDrawerTab, setActiveDrawerTab] = useState<DrawerTab>('editor')
 
   const toggleSidebar = useCallback(() => setSidebarOpen((v) => !v), [])
 
@@ -31,15 +26,6 @@ function AppLayout() {
         <section className="flex-1 flex flex-col bg-white min-w-0 relative overflow-hidden">
           <Outlet />
         </section>
-
-        {/* Right Drawer - Desktop: always visible, Mobile: bottom sheet */}
-        <RightDrawer
-          isOpen={drawerOpen}
-          onClose={() => setDrawerOpen(false)}
-          onOpen={() => setDrawerOpen(true)}
-          activeTab={activeDrawerTab}
-          onTabChange={setActiveDrawerTab}
-        />
       </main>
     </div>
   )


### PR DESCRIPTION
Hides the right side panel and mobile floating button until they are fully implemented. 
The `RightDrawer` component was removed from `src/routes/_app.tsx`, and the `DrawerTab` type was moved into `RightDrawer.tsx` to keep it compilable. 
Verified with screenshots that the panel and button are no longer visible.

Fixes #42

---
*PR created automatically by Jules for task [14636359027738621333](https://jules.google.com/task/14636359027738621333) started by @MrOrz*