### PR TITLE
feat: warn before leaving with unsaved input or active stream

### DIFF
--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -10,6 +10,7 @@ interface ChatAreaProps {
   isStreaming: boolean
   onSendMessage: (text: string) => void
   onStop?: () => void
+  sessionId?: string
 }
 
 export function ChatArea({
@@ -17,6 +18,7 @@ export function ChatArea({
   isStreaming,
   onSendMessage,
   onStop,
+  sessionId,
 }: ChatAreaProps) {
   const scrollRef = useRef<HTMLDivElement>(null)
 
@@ -85,6 +87,8 @@ export function ChatArea({
         onSend={onSendMessage}
         onStop={onStop}
         isStreaming={isStreaming}
+        key={sessionId} // Reset input when session changes
+        sessionId={sessionId}
       />
     </>
   )

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useBlocker } from '@tanstack/react-router'
 
+// Map of draft messages by sessionId
 const drafts = new Map<string, string>()
 
 interface ChatInputProps {

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -1,4 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useBlocker } from '@tanstack/react-router'
+
+const drafts = new Map<string, string>()
 
 interface ChatInputProps {
   onSend: (text: string) => void
@@ -6,6 +9,7 @@ interface ChatInputProps {
   isStreaming?: boolean
   disabled?: boolean
   placeholder?: string
+  sessionId?: string
 }
 
 export function ChatInput({
@@ -14,8 +18,11 @@ export function ChatInput({
   isStreaming,
   disabled,
   placeholder = '詢問後續問題或要求修改...',
+  sessionId,
 }: ChatInputProps) {
-  const [value, setValue] = useState('')
+  const [value, setValue] = useState(() =>
+    sessionId ? (drafts.get(sessionId) ?? '') : '',
+  )
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   // Auto-resize textarea
@@ -26,11 +33,28 @@ export function ChatInput({
     el.style.height = `${Math.min(el.scrollHeight, 128)}px`
   }, [value])
 
+  const handleChange = useCallback(
+    (newValue: string) => {
+      setValue(newValue)
+      if (sessionId) {
+        if (newValue) drafts.set(sessionId, newValue)
+        else drafts.delete(sessionId)
+      }
+    },
+    [sessionId],
+  )
+
+  useBlocker({
+    shouldBlockFn: () => false,
+    enableBeforeUnload: () => isStreaming || !!value.trim(),
+  })
+
   const handleSubmit = useCallback(() => {
     if (!value.trim() || disabled) return
+    if (sessionId) drafts.delete(sessionId)
     onSend(value.trim())
     setValue('')
-  }, [value, disabled, onSend])
+  }, [value, disabled, onSend, sessionId])
 
   return (
     <div className="px-3 md:px-4 pb-3 md:pb-4 pt-2 bg-white shrink-0 z-10">
@@ -38,7 +62,7 @@ export function ChatInput({
         <textarea
           ref={textareaRef}
           value={value}
-          onChange={(e) => setValue(e.target.value)}
+          onChange={(e) => handleChange(e.target.value)}
           onKeyDown={(e) => {
             if (
               e.key === 'Enter' &&

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -18,11 +18,9 @@ export function ChatInput({
   isStreaming,
   disabled,
   placeholder = '詢問後續問題或要求修改...',
-  sessionId,
+  sessionId = '', // ChatInput without sessionId will connect to empty sessionId
 }: ChatInputProps) {
-  const [value, setValue] = useState(() =>
-    sessionId ? (drafts.get(sessionId) ?? '') : '',
-  )
+  const [value, setValue] = useState(() => drafts.get(sessionId) ?? '')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   // Auto-resize textarea
@@ -36,10 +34,8 @@ export function ChatInput({
   const handleChange = useCallback(
     (newValue: string) => {
       setValue(newValue)
-      if (sessionId) {
-        if (newValue) drafts.set(sessionId, newValue)
-        else drafts.delete(sessionId)
-      }
+      if (newValue) drafts.set(sessionId, newValue)
+      else drafts.delete(sessionId)
     },
     [sessionId],
   )
@@ -51,7 +47,7 @@ export function ChatInput({
 
   const handleSubmit = useCallback(() => {
     if (!value.trim() || disabled) return
-    if (sessionId) drafts.delete(sessionId)
+    drafts.delete(sessionId)
     onSend(value.trim())
     setValue('')
   }, [value, disabled, onSend, sessionId])

--- a/src/routes/_app/session.$sessionId.tsx
+++ b/src/routes/_app/session.$sessionId.tsx
@@ -31,6 +31,7 @@ function SessionPage() {
         isStreaming={isStreaming}
         onSendMessage={sendMessage}
         onStop={stopGeneration}
+        sessionId={sessionId}
       />
     </>
   )


### PR DESCRIPTION
Closes #37

## Summary

- `useBlocker` with `enableBeforeUnload` triggers the browser's native dialog when closing/refreshing a tab while there is unsent input or an ongoing stream
- Unsent input is saved per session in a module-level `Map` and restored when returning to the same session, allowing free switching between sessions without data loss
- `key={sessionId}` on `ChatInput` resets the component state when switching sessions

## Test plan

- [x] Type in a session input → close/refresh tab → browser shows native confirmation dialog 

https://github.com/user-attachments/assets/1924e998-e554-405d-8a0b-04c9eaa888d4

- [x] Start streaming → close/refresh tab → browser shows native confirmation dialog 

    https://github.com/user-attachments/assets/b336667b-c992-49df-8ab4-7cc3400a7120

- [x] Type in a session → switch to another session → come back → draft is restored 

    https://github.com/user-attachments/assets/94a4061f-7305-4796-a4bf-5d8fa847464c

- [x] Send a message → draft is cleared, no confirmation on tab close
- [x] Empty input + no stream → close tab → no dialog

    https://github.com/user-attachments/assets/e43e59a6-e879-4977-af47-4f7474578da6





🤖 Generated with [Claude Code](https://claude.com/claude-code)