### PR TITLE
fix: decouple Node.js and Python dependency installation in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM node:22-alpine AS builder
 RUN corepack enable pnpm
 WORKDIR /app
 
-# Install deps (skip postinstall that would try to run uv)
-COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile --ignore-scripts
+# Install deps
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
 
 # Copy source and build
 COPY . .

--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ This is the web application for [Cofacts.ai](https://cofacts.ai), a chat-based A
 
 ## Getting Started
 
-1. Install dependencies:
+1. Install Node.js dependencies:
 
 ```bash
 pnpm install
 ```
+
+> **Note:** This will *not* install Python dependencies. You must run the next step manually.
 
 2. Install Python dependencies for the ADK agent:
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "format": "prettier",
     "check": "prettier --write . && eslint --fix",
     "install:agent": "uv sync --project adk",
-    "postinstall": "pnpm run install:agent",
     "typegen": "openapi-typescript http://localhost:8000/openapi.json -o src/lib/adk-types.d.ts && sed -i '' 's/: unknown/: {}/g' src/lib/adk-types.d.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Problem
Docker build fails because `pnpm run build` triggers `postinstall` which attempts to run `uv sync`. The Node.js Docker image lacks Python and `uv`. Additionally, `pnpm-workspace.yaml` was missing from the initial `COPY` in the Dockerfile, causing cache invalidation and re-installation attempts.

## Solution
1. Remove `postinstall` from `package.json`.
2. Update `Dockerfile` to include `pnpm-workspace.yaml` and remove `--ignore-scripts` for cleaner builds.
3. Update `README.md` to reflect the manual installation step for Python dependencies.