### PR TITLE
feat: thread authenticated user id through chat, feedback, and ADK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,13 +5,9 @@ COFACTS_API_URL=https://dev-api.cofacts.tw
 # Server-side (optional) — ADK agent URL, defaults to http://localhost:8000
 # ADK_URL=http://localhost:8000
 
-# Browser-safe (public key only, VITE_ prefix exposes to Vite client bundle)
-VITE_LANGFUSE_PUBLIC_KEY=pk-lf-...
-VITE_LANGFUSE_BASE_URL=https://langfuse.cofacts.tw
-
 # Server-side (optional) — Langfuse keys for reading back user feedback scores.
-# Required to persist thumbs-up/down across reloads. Same key pair as the
-# browser-safe ones above; secret key MUST stay server-side.
+# Required to persist thumbs-up/down across reloads. Secret key MUST stay
+# server-side; all Langfuse traffic is proxied through the BFF.
 LANGFUSE_BASE_URL=https://langfuse.cofacts.tw
 LANGFUSE_PUBLIC_KEY=pk-lf-...
 LANGFUSE_SECRET_KEY=sk-lf-...

--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,10 @@ COFACTS_API_URL=https://dev-api.cofacts.tw
 # Browser-safe (public key only, VITE_ prefix exposes to Vite client bundle)
 VITE_LANGFUSE_PUBLIC_KEY=pk-lf-...
 VITE_LANGFUSE_BASE_URL=https://langfuse.cofacts.tw
+
+# Server-side (optional) — Langfuse keys for reading back user feedback scores.
+# Required to persist thumbs-up/down across reloads. Same key pair as the
+# browser-safe ones above; secret key MUST stay server-side.
+LANGFUSE_BASE_URL=https://langfuse.cofacts.tw
+LANGFUSE_PUBLIC_KEY=pk-lf-...
+LANGFUSE_SECRET_KEY=sk-lf-...

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -56,6 +56,3 @@ jobs:
           tags: cofacts/site:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            VITE_LANGFUSE_PUBLIC_KEY=${{ secrets.LANGFUSE_PUBLIC_KEY }}
-            VITE_LANGFUSE_BASE_URL=https://langfuse.cofacts.tw

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,8 +84,6 @@ jobs:
         run: |
           # Build frontend
           docker build \
-            --build-arg VITE_LANGFUSE_PUBLIC_KEY=${{ secrets.LANGFUSE_PUBLIC_KEY }} \
-            --build-arg VITE_LANGFUSE_BASE_URL="https://langfuse.cofacts.tw" \
             -t asia-east1-docker.pkg.dev/$PROJECT_ID/cofacts-ai/frontend:$SHA -f Dockerfile .
           docker push asia-east1-docker.pkg.dev/$PROJECT_ID/cofacts-ai/frontend:$SHA
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ RUN pnpm install --frozen-lockfile
 
 # Copy source and build
 COPY . .
-ARG VITE_LANGFUSE_PUBLIC_KEY
-ARG VITE_LANGFUSE_BASE_URL
 RUN pnpm run build
 
 # --- runtime ---

--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -3,9 +3,7 @@ import { UserMessage } from './UserMessage'
 import { AgentMessage } from './AgentMessage'
 import { FeedbackButtons } from './FeedbackButtons'
 import { ChatInput } from './ChatInput'
-import { LoginPrompt } from './LoginPrompt'
 import type { ChatMessage } from '@/lib/adk'
-import { useAuth } from '@/lib/auth'
 
 interface ChatAreaProps {
   messages: Array<ChatMessage>
@@ -22,7 +20,6 @@ export function ChatArea({
   onStop,
   sessionId,
 }: ChatAreaProps) {
-  const { user } = useAuth()
   const scrollRef = useRef<HTMLDivElement>(null)
 
   // Auto-scroll to bottom on new messages
@@ -86,17 +83,13 @@ export function ChatArea({
       </div>
 
       {/* Input area */}
-      {user ? (
-        <ChatInput
-          onSend={onSendMessage}
-          onStop={onStop}
-          isStreaming={isStreaming}
-          key={sessionId} // Reset input when session changes
-          sessionId={sessionId}
-        />
-      ) : (
-        <LoginPrompt message="登入後即可繼續與 Cofacts.ai 對話" />
-      )}
+      <ChatInput
+        onSend={onSendMessage}
+        onStop={onStop}
+        isStreaming={isStreaming}
+        key={sessionId} // Reset input when session changes
+        sessionId={sessionId}
+      />
     </>
   )
 }

--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -3,7 +3,9 @@ import { UserMessage } from './UserMessage'
 import { AgentMessage } from './AgentMessage'
 import { FeedbackButtons } from './FeedbackButtons'
 import { ChatInput } from './ChatInput'
+import { LoginPrompt } from './LoginPrompt'
 import type { ChatMessage } from '@/lib/adk'
+import { useAuth } from '@/lib/auth'
 
 interface ChatAreaProps {
   messages: Array<ChatMessage>
@@ -20,6 +22,7 @@ export function ChatArea({
   onStop,
   sessionId,
 }: ChatAreaProps) {
+  const { user } = useAuth()
   const scrollRef = useRef<HTMLDivElement>(null)
 
   // Auto-scroll to bottom on new messages
@@ -83,13 +86,17 @@ export function ChatArea({
       </div>
 
       {/* Input area */}
-      <ChatInput
-        onSend={onSendMessage}
-        onStop={onStop}
-        isStreaming={isStreaming}
-        key={sessionId} // Reset input when session changes
-        sessionId={sessionId}
-      />
+      {user ? (
+        <ChatInput
+          onSend={onSendMessage}
+          onStop={onStop}
+          isStreaming={isStreaming}
+          key={sessionId} // Reset input when session changes
+          sessionId={sessionId}
+        />
+      ) : (
+        <LoginPrompt message="登入後即可繼續與 Cofacts.ai 對話" />
+      )}
     </>
   )
 }

--- a/src/components/FeedbackButtons.tsx
+++ b/src/components/FeedbackButtons.tsx
@@ -35,7 +35,6 @@ export function FeedbackButtons({ traceId }: FeedbackButtonsProps) {
           value: 0,
           dataType: 'NUMERIC',
           comment: '',
-          metadata: { userId: user?.id ?? null },
         })
       }
     } else {
@@ -48,7 +47,6 @@ export function FeedbackButtons({ traceId }: FeedbackButtonsProps) {
           name: 'user-thumbs',
           value: next,
           dataType: 'NUMERIC',
-          metadata: { userId: user?.id ?? null },
         })
       }
     }
@@ -64,7 +62,6 @@ export function FeedbackButtons({ traceId }: FeedbackButtonsProps) {
         value: feedbackGiven,
         dataType: 'NUMERIC',
         comment,
-        metadata: { userId: user?.id ?? null },
       })
     }
   }

--- a/src/components/FeedbackButtons.tsx
+++ b/src/components/FeedbackButtons.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { LangfuseWeb } from 'langfuse'
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
 import { FeedbackPopoverContent } from './FeedbackPopoverContent'
+import { useAuth } from '@/lib/auth'
 
 const langfuse = import.meta.env.VITE_LANGFUSE_PUBLIC_KEY
   ? new LangfuseWeb({
@@ -15,6 +16,7 @@ interface FeedbackButtonsProps {
 }
 
 export function FeedbackButtons({ traceId }: FeedbackButtonsProps) {
+  const { user } = useAuth()
   const [feedbackGiven, setFeedbackGiven] = useState<1 | -1 | null>(null)
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
 
@@ -33,6 +35,7 @@ export function FeedbackButtons({ traceId }: FeedbackButtonsProps) {
           value: 0,
           dataType: 'NUMERIC',
           comment: '',
+          metadata: { userId: user?.id ?? null },
         })
       }
     } else {
@@ -45,6 +48,7 @@ export function FeedbackButtons({ traceId }: FeedbackButtonsProps) {
           name: 'user-thumbs',
           value: next,
           dataType: 'NUMERIC',
+          metadata: { userId: user?.id ?? null },
         })
       }
     }
@@ -60,6 +64,7 @@ export function FeedbackButtons({ traceId }: FeedbackButtonsProps) {
         value: feedbackGiven,
         dataType: 'NUMERIC',
         comment,
+        metadata: { userId: user?.id ?? null },
       })
     }
   }

--- a/src/components/FeedbackButtons.tsx
+++ b/src/components/FeedbackButtons.tsx
@@ -1,17 +1,12 @@
 import { useEffect, useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { LangfuseWeb } from 'langfuse'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
 import { FeedbackPopoverContent } from './FeedbackPopoverContent'
 import { useAuth } from '@/lib/auth'
-import { getFeedbackForTrace } from '@/server/feedbackScores.functions'
-
-const langfuse = import.meta.env.VITE_LANGFUSE_PUBLIC_KEY
-  ? new LangfuseWeb({
-      publicKey: import.meta.env.VITE_LANGFUSE_PUBLIC_KEY,
-      baseUrl: import.meta.env.VITE_LANGFUSE_BASE_URL,
-    })
-  : null
+import {
+  getFeedbackForTrace,
+  submitFeedbackForTrace,
+} from '@/server/feedbackScores.functions'
 
 interface FeedbackButtonsProps {
   traceId: string
@@ -33,50 +28,28 @@ export function FeedbackButtons({ traceId }: FeedbackButtonsProps) {
     if (persistedFeedback) setFeedbackGiven(persistedFeedback.value)
   }, [persistedFeedback])
 
-  const handleFeedback = (e: React.MouseEvent, value: 1 | -1) => {
+  const submitFeedback = useMutation({
+    mutationFn: (input: { value: 1 | -1 | 0; comment?: string }) =>
+      submitFeedbackForTrace({ data: { traceId, ...input } }),
+  })
+
+  const handleFeedback = (value: 1 | -1) => {
     const next = feedbackGiven === value ? null : value
     setFeedbackGiven(next)
 
     if (next === null) {
-      // Re-clicking same button -> clear feedback
       setIsPopoverOpen(false)
-      if (langfuse) {
-        langfuse.score({
-          id: `user-${traceId}`,
-          traceId,
-          name: 'user-thumbs',
-          value: 0,
-          dataType: 'NUMERIC',
-          comment: '',
-        })
-      }
+      submitFeedback.mutate({ value: 0, comment: '' })
     } else {
-      // New feedback
       setIsPopoverOpen(true)
-      if (langfuse) {
-        langfuse.score({
-          id: `user-${traceId}`,
-          traceId,
-          name: 'user-thumbs',
-          value: next,
-          dataType: 'NUMERIC',
-        })
-      }
+      submitFeedback.mutate({ value: next })
     }
   }
 
   const handleCommentSubmit = (comment: string) => {
     setIsPopoverOpen(false)
-    if (langfuse && feedbackGiven !== null) {
-      langfuse.score({
-        id: `user-${traceId}`,
-        traceId,
-        name: 'user-thumbs',
-        value: feedbackGiven,
-        dataType: 'NUMERIC',
-        comment,
-      })
-    }
+    if (feedbackGiven === null) return
+    submitFeedback.mutate({ value: feedbackGiven, comment })
   }
 
   return (
@@ -89,7 +62,7 @@ export function FeedbackButtons({ traceId }: FeedbackButtonsProps) {
       >
         <div className="flex gap-3">
           <PopoverTrigger
-            onClick={(e) => handleFeedback(e, 1)}
+            onClick={() => handleFeedback(1)}
             className={`p-1 rounded hover:bg-gray-100 transition-colors ${
               feedbackGiven === 1
                 ? 'text-primary'
@@ -101,7 +74,7 @@ export function FeedbackButtons({ traceId }: FeedbackButtonsProps) {
             </span>
           </PopoverTrigger>
           <PopoverTrigger
-            onClick={(e) => handleFeedback(e, -1)}
+            onClick={() => handleFeedback(-1)}
             className={`p-1 rounded hover:bg-gray-100 transition-colors ${
               feedbackGiven === -1
                 ? 'text-destructive'

--- a/src/components/FeedbackButtons.tsx
+++ b/src/components/FeedbackButtons.tsx
@@ -1,8 +1,10 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { LangfuseWeb } from 'langfuse'
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
 import { FeedbackPopoverContent } from './FeedbackPopoverContent'
 import { useAuth } from '@/lib/auth'
+import { getFeedbackForTrace } from '@/server/feedbackScores.functions'
 
 const langfuse = import.meta.env.VITE_LANGFUSE_PUBLIC_KEY
   ? new LangfuseWeb({
@@ -19,6 +21,17 @@ export function FeedbackButtons({ traceId }: FeedbackButtonsProps) {
   const { user } = useAuth()
   const [feedbackGiven, setFeedbackGiven] = useState<1 | -1 | null>(null)
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
+
+  const { data: persistedFeedback } = useQuery({
+    queryKey: ['feedback', traceId, user?.id ?? null],
+    queryFn: () => getFeedbackForTrace({ data: traceId }),
+    enabled: !!user,
+    staleTime: Infinity,
+  })
+
+  useEffect(() => {
+    if (persistedFeedback) setFeedbackGiven(persistedFeedback.value)
+  }, [persistedFeedback])
 
   const handleFeedback = (e: React.MouseEvent, value: 1 | -1) => {
     const next = feedbackGiven === value ? null : value

--- a/src/components/LoggedOutLanding.tsx
+++ b/src/components/LoggedOutLanding.tsx
@@ -1,0 +1,10 @@
+import { LoginPrompt } from './LoginPrompt'
+import { WelcomeHero } from './WelcomeHero'
+
+export function LoggedOutLanding() {
+  return (
+    <WelcomeHero>
+      <LoginPrompt message="登入後即可開始使用 Cofacts.ai" />
+    </WelcomeHero>
+  )
+}

--- a/src/components/LoginPrompt.tsx
+++ b/src/components/LoginPrompt.tsx
@@ -1,0 +1,23 @@
+import { useAuth } from '@/lib/auth'
+
+interface LoginPromptProps {
+  message?: string
+}
+
+export function LoginPrompt({
+  message = '登入後即可開始與 Cofacts.ai 對話',
+}: LoginPromptProps) {
+  const { login } = useAuth()
+  return (
+    <div className="border-t border-border-subtle bg-white p-4 flex flex-col items-center gap-3">
+      <p className="text-sm text-text-muted text-center">{message}</p>
+      <button
+        type="button"
+        onClick={() => login()}
+        className="px-4 py-1.5 rounded-full bg-primary text-white text-sm font-medium hover:bg-primary/90 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+      >
+        登入 / 註冊
+      </button>
+    </div>
+  )
+}

--- a/src/components/LoginPrompt.tsx
+++ b/src/components/LoginPrompt.tsx
@@ -1,12 +1,10 @@
 import { useAuth } from '@/lib/auth'
 
 interface LoginPromptProps {
-  message?: string
+  message: string
 }
 
-export function LoginPrompt({
-  message = '登入後即可開始與 Cofacts.ai 對話',
-}: LoginPromptProps) {
+export function LoginPrompt({ message }: LoginPromptProps) {
   const { login } = useAuth()
   return (
     <div className="border-t border-border-subtle bg-white p-4 flex flex-col items-center gap-3">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import type { SessionListItem } from '@/lib/chatSessions.functions'
 import { useSessions } from '@/hooks/useSessions'
 import { updateSessionTitle } from '@/lib/chatSessions.functions'
+import { handleAuthExpired, isAuthExpiredError } from '@/lib/authExpired'
 
 interface SidebarProps {
   isOpen: boolean
@@ -63,7 +64,11 @@ function SessionItem({ session, isActive, onClose }: SessionItemProps) {
       })
       await queryClient.invalidateQueries({ queryKey: ['sessions'] })
     } catch (err) {
-      console.error('Failed to update session title:', err)
+      if (isAuthExpiredError(err)) {
+        handleAuthExpired(queryClient)
+      } else {
+        console.error('Failed to update session title:', err)
+      }
     } finally {
       handleCancelEdit()
     }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -65,7 +65,7 @@ function SessionItem({ session, isActive, onClose }: SessionItemProps) {
       await queryClient.invalidateQueries({ queryKey: ['sessions'] })
     } catch (err) {
       if (isAuthExpiredError(err)) {
-        handleAuthExpired(queryClient)
+        handleAuthExpired()
       } else {
         console.error('Failed to update session title:', err)
       }

--- a/src/components/WelcomeHero.tsx
+++ b/src/components/WelcomeHero.tsx
@@ -1,0 +1,23 @@
+interface WelcomeHeroProps {
+  children?: React.ReactNode
+}
+
+export function WelcomeHero({ children }: WelcomeHeroProps) {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center p-6">
+      <div className="max-w-2xl w-full text-center space-y-6">
+        <div className="w-16 h-16 bg-primary rounded-full flex items-center justify-center text-white font-bold text-2xl mx-auto shadow-lg">
+          C
+        </div>
+        <h1 className="text-2xl font-bold text-text-main">
+          歡迎使用 Cofacts.ai
+        </h1>
+        <p className="text-text-muted leading-relaxed">
+          貼上可疑訊息或 Cofacts 文章連結，AI 協助您進行查核、撰寫回應。
+        </p>
+      </div>
+
+      {children && <div className="max-w-2xl w-full mt-8">{children}</div>}
+    </div>
+  )
+}

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'vitest'
+import { QueryClient } from '@tanstack/react-query'
+
+import { clearUserScopedCache } from '../auth'
+
+describe('clearUserScopedCache', () => {
+  test('removes me / sessions / chat caches so an anonymous viewer cannot read prior user data', () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { staleTime: Infinity, gcTime: Infinity } },
+    })
+    queryClient.setQueryData(['me'], {
+      id: 'user-1',
+      name: 'Alice',
+      avatarUrl: null,
+      avatarType: null,
+      avatarData: null,
+    })
+    queryClient.setQueryData(
+      ['sessions'],
+      [{ id: 's1', name: 'old', lastUpdateTime: 0 }],
+    )
+    queryClient.setQueryData(['chat', 's1'], { messages: ['secret-1'] })
+    queryClient.setQueryData(['chat', 's2'], { messages: ['secret-2'] })
+
+    clearUserScopedCache(queryClient)
+
+    expect(queryClient.getQueryData(['me'])).toBeNull()
+    expect(queryClient.getQueryData(['sessions'])).toBeUndefined()
+    expect(queryClient.getQueryData(['chat', 's1'])).toBeUndefined()
+    expect(queryClient.getQueryData(['chat', 's2'])).toBeUndefined()
+  })
+
+  test('leaves unrelated caches untouched', () => {
+    const queryClient = new QueryClient()
+    queryClient.setQueryData(['something-else'], { keep: true })
+
+    clearUserScopedCache(queryClient)
+
+    expect(queryClient.getQueryData(['something-else'])).toEqual({ keep: true })
+  })
+})

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -4,7 +4,7 @@ import { QueryClient } from '@tanstack/react-query'
 import { clearUserScopedCache } from '../auth'
 
 describe('clearUserScopedCache', () => {
-  test('removes me / sessions / chat caches so an anonymous viewer cannot read prior user data', () => {
+  test('removes me / sessions / chat / feedback caches so an anonymous viewer cannot read prior user data', () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { staleTime: Infinity, gcTime: Infinity } },
     })
@@ -21,6 +21,10 @@ describe('clearUserScopedCache', () => {
     )
     queryClient.setQueryData(['chat', 's1'], { messages: ['secret-1'] })
     queryClient.setQueryData(['chat', 's2'], { messages: ['secret-2'] })
+    queryClient.setQueryData(['feedback', 'trace-1', 'user-1'], {
+      value: 1,
+      comment: 'nice',
+    })
 
     clearUserScopedCache(queryClient)
 
@@ -28,6 +32,9 @@ describe('clearUserScopedCache', () => {
     expect(queryClient.getQueryData(['sessions'])).toBeUndefined()
     expect(queryClient.getQueryData(['chat', 's1'])).toBeUndefined()
     expect(queryClient.getQueryData(['chat', 's2'])).toBeUndefined()
+    expect(
+      queryClient.getQueryData(['feedback', 'trace-1', 'user-1']),
+    ).toBeUndefined()
   })
 
   test('leaves unrelated caches untouched', () => {

--- a/src/lib/__tests__/authExpired.test.ts
+++ b/src/lib/__tests__/authExpired.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { QueryClient } from '@tanstack/react-query'
+import {
+  AUTH_EXPIRED_EVENT,
+  AUTH_EXPIRED_MESSAGE,
+  handleAuthExpired,
+  isAuthExpiredError,
+} from '../authExpired'
+
+describe('isAuthExpiredError', () => {
+  test('returns true for an Error with the AUTH_EXPIRED message', () => {
+    expect(isAuthExpiredError(new Error(AUTH_EXPIRED_MESSAGE))).toBe(true)
+  })
+
+  test('returns false for other errors and non-error values', () => {
+    expect(isAuthExpiredError(new Error('something else'))).toBe(false)
+    expect(isAuthExpiredError(new Response(null, { status: 401 }))).toBe(false)
+    expect(isAuthExpiredError(null)).toBe(false)
+    expect(isAuthExpiredError(undefined)).toBe(false)
+    expect(isAuthExpiredError({ message: AUTH_EXPIRED_MESSAGE })).toBe(false)
+    expect(isAuthExpiredError(AUTH_EXPIRED_MESSAGE)).toBe(false)
+  })
+})
+
+describe('handleAuthExpired', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient()
+    queryClient.setQueryData(['me'], { id: 'u1', name: 'x' })
+    queryClient.setQueryData(['sessions'], [{ id: 's1' }])
+  })
+
+  afterEach(() => {
+    queryClient.clear()
+  })
+
+  test('clears user-scoped cache and dispatches event', () => {
+    const handler = vi.fn()
+    window.addEventListener(AUTH_EXPIRED_EVENT, handler)
+
+    handleAuthExpired(queryClient)
+
+    expect(queryClient.getQueryData(['me'])).toBeNull()
+    expect(queryClient.getQueryData(['sessions'])).toBeUndefined()
+    expect(handler).toHaveBeenCalledTimes(1)
+
+    window.removeEventListener(AUTH_EXPIRED_EVENT, handler)
+  })
+})

--- a/src/lib/__tests__/authExpired.test.ts
+++ b/src/lib/__tests__/authExpired.test.ts
@@ -1,6 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { QueryClient } from '@tanstack/react-query'
+import { describe, expect, test, vi } from 'vitest'
 import {
   AUTH_EXPIRED_EVENT,
   AUTH_EXPIRED_MESSAGE,
@@ -24,26 +23,12 @@ describe('isAuthExpiredError', () => {
 })
 
 describe('handleAuthExpired', () => {
-  let queryClient: QueryClient
-
-  beforeEach(() => {
-    queryClient = new QueryClient()
-    queryClient.setQueryData(['me'], { id: 'u1', name: 'x' })
-    queryClient.setQueryData(['sessions'], [{ id: 's1' }])
-  })
-
-  afterEach(() => {
-    queryClient.clear()
-  })
-
-  test('clears user-scoped cache and dispatches event', () => {
+  test('dispatches AUTH_EXPIRED_EVENT on window', () => {
     const handler = vi.fn()
     window.addEventListener(AUTH_EXPIRED_EVENT, handler)
 
-    handleAuthExpired(queryClient)
+    handleAuthExpired()
 
-    expect(queryClient.getQueryData(['me'])).toBeNull()
-    expect(queryClient.getQueryData(['sessions'])).toBeUndefined()
     expect(handler).toHaveBeenCalledTimes(1)
 
     window.removeEventListener(AUTH_EXPIRED_EVENT, handler)

--- a/src/lib/adkClient.ts
+++ b/src/lib/adkClient.ts
@@ -5,5 +5,3 @@ const ADK_BASE_URL = process.env.ADK_URL || 'http://localhost:8000'
 
 export const adkClient = createClient<paths>({ baseUrl: ADK_BASE_URL })
 export const ADK_APP_NAME = 'cofacts_ai'
-// TODO: 之後登入實作後，改從 request 解析 user ID
-export const ADK_USER_ID = 'anonymous'

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -70,16 +70,17 @@ export function AuthProvider({
     staleTime: Infinity,
   })
 
-  // Open LoginModal whenever any client-side call detects 401. The redirect
-  // target is the current pathname so the user lands back where they were
-  // after re-authenticating.
+  // Owns the AUTH_EXPIRED_EVENT reaction: clear user-scoped caches and
+  // open LoginModal anchored to the current pathname so re-auth lands the
+  // user back where they were.
   useEffect(() => {
     const onAuthExpired = () => {
+      clearUserScopedCache(queryClient)
       setPendingRedirect(router.state.location.pathname)
     }
     window.addEventListener(AUTH_EXPIRED_EVENT, onAuthExpired)
     return () => window.removeEventListener(AUTH_EXPIRED_EVENT, onAuthExpired)
-  }, [router])
+  }, [router, queryClient])
 
   const login = useCallback((redirectTo?: string) => {
     setPendingRedirect(redirectTo ?? '')

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -12,14 +12,25 @@
 import { createContext, useCallback, useContext, useMemo, useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useServerFn } from '@tanstack/react-start'
+import type { QueryClient } from '@tanstack/react-query'
+import type { CofactsUser } from '@/server/me.functions'
 import { logout as logoutServerFn } from '@/server/auth.functions'
 import { getCurrentUserServerFn } from '@/server/me.functions'
-import type { CofactsUser } from '@/server/me.functions'
 import { LoginModal } from '@/components/LoginModal'
 
 export type { CofactsUser }
 
 const ME_QUERY_KEY = ['me'] as const
+
+// Drop user-scoped caches so the previous user's session list and chat
+// messages cannot be read by an anonymous viewer in the same tab. Both
+// queries use staleTime/gcTime: Infinity, so removeQueries (not invalidate)
+// is required for immediate eviction.
+export function clearUserScopedCache(queryClient: QueryClient) {
+  queryClient.setQueryData(ME_QUERY_KEY, null)
+  queryClient.removeQueries({ queryKey: ['sessions'] })
+  queryClient.removeQueries({ queryKey: ['chat'] })
+}
 
 interface AuthState {
   user: CofactsUser | null
@@ -58,7 +69,7 @@ export function AuthProvider({
     } catch {
       // best-effort: clear local state even if the network call fails
     }
-    queryClient.setQueryData(ME_QUERY_KEY, null)
+    clearUserScopedCache(queryClient)
   }, [callLogout, queryClient])
 
   const value = useMemo<AuthState>(

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -9,14 +9,23 @@
 // flow is initiated via the `login` server function (which hides the upstream
 // rumors-api origin).
 
-import { createContext, useCallback, useContext, useMemo, useState } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useRouter } from '@tanstack/react-router'
 import { useServerFn } from '@tanstack/react-start'
 import type { QueryClient } from '@tanstack/react-query'
 import type { CofactsUser } from '@/server/me.functions'
 import { logout as logoutServerFn } from '@/server/auth.functions'
 import { getCurrentUserServerFn } from '@/server/me.functions'
 import { LoginModal } from '@/components/LoginModal'
+import { AUTH_EXPIRED_EVENT } from './authExpired'
 
 export type { CofactsUser }
 
@@ -50,6 +59,7 @@ export function AuthProvider({
   serverLoadedUser?: CofactsUser | null
 }) {
   const queryClient = useQueryClient()
+  const router = useRouter()
   const callLogout = useServerFn(logoutServerFn)
   const [pendingRedirect, setPendingRedirect] = useState<string | null>(null)
 
@@ -59,6 +69,17 @@ export function AuthProvider({
     initialData: serverLoadedUser ?? null,
     staleTime: Infinity,
   })
+
+  // Open LoginModal whenever any client-side call detects 401. The redirect
+  // target is the current pathname so the user lands back where they were
+  // after re-authenticating.
+  useEffect(() => {
+    const onAuthExpired = () => {
+      setPendingRedirect(router.state.location.pathname)
+    }
+    window.addEventListener(AUTH_EXPIRED_EVENT, onAuthExpired)
+    return () => window.removeEventListener(AUTH_EXPIRED_EVENT, onAuthExpired)
+  }, [router])
 
   const login = useCallback((redirectTo?: string) => {
     setPendingRedirect(redirectTo ?? '')

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -30,6 +30,7 @@ export function clearUserScopedCache(queryClient: QueryClient) {
   queryClient.setQueryData(ME_QUERY_KEY, null)
   queryClient.removeQueries({ queryKey: ['sessions'] })
   queryClient.removeQueries({ queryKey: ['chat'] })
+  queryClient.removeQueries({ queryKey: ['feedback'] })
 }
 
 interface AuthState {

--- a/src/lib/authExpired.ts
+++ b/src/lib/authExpired.ts
@@ -1,12 +1,7 @@
-// Centralized 'session expired' handler. When the client detects an expired
-// or missing session cookie, we must (a) drop user-scoped caches so stale
-// data from the previous session isn't shown, (b) reset useAuth().user to
-// null so the layout switches to the logged-out landing, and (c) prompt the
-// user to re-authenticate. We use a custom DOM event to keep this module
-// React-free; AuthProvider listens for it and opens LoginModal.
-
-import type { QueryClient } from '@tanstack/react-query'
-import { clearUserScopedCache } from './auth'
+// Auth-expired signal. Callers dispatch AUTH_EXPIRED_EVENT (or throw an
+// Error with AUTH_EXPIRED_MESSAGE that the router-level error handler
+// dispatches for them); AuthProvider listens, clears user-scoped caches,
+// and opens LoginModal.
 
 export const AUTH_EXPIRED_EVENT = 'cofacts:auth-expired'
 
@@ -20,8 +15,7 @@ export function isAuthExpiredError(err: unknown): boolean {
   return err instanceof Error && err.message === AUTH_EXPIRED_MESSAGE
 }
 
-export function handleAuthExpired(queryClient: QueryClient): void {
-  clearUserScopedCache(queryClient)
+export function handleAuthExpired(): void {
   if (typeof window !== 'undefined') {
     window.dispatchEvent(new CustomEvent(AUTH_EXPIRED_EVENT))
   }

--- a/src/lib/authExpired.ts
+++ b/src/lib/authExpired.ts
@@ -1,0 +1,29 @@
+// Centralized 'session expired' handler. When any client-side call to a
+// server function or fetch returns 401 (cookie/JWT expired or missing), we
+// must (a) drop user-scoped caches so stale data from the previous session
+// isn't shown, (b) reset useAuth().user to null so the layout switches to
+// the logged-out landing, and (c) prompt the user to re-authenticate. We
+// use a custom DOM event to keep this module React-free; AuthProvider
+// listens for it and opens LoginModal.
+
+import type { QueryClient } from '@tanstack/react-query'
+import { clearUserScopedCache } from './auth'
+
+export const AUTH_EXPIRED_EVENT = 'cofacts:auth-expired'
+
+// Sentinel `Error.message` thrown by server functions on auth failure and
+// matched here on the client. TanStack Start's serverFn handler serializes
+// `Error` (via seroval) and the client re-throws it, so plain string
+// matching is the contract that survives the RPC boundary.
+export const AUTH_EXPIRED_MESSAGE = 'AUTH_EXPIRED'
+
+export function isAuthExpiredError(err: unknown): boolean {
+  return err instanceof Error && err.message === AUTH_EXPIRED_MESSAGE
+}
+
+export function handleAuthExpired(queryClient: QueryClient): void {
+  clearUserScopedCache(queryClient)
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(AUTH_EXPIRED_EVENT))
+  }
+}

--- a/src/lib/authExpired.ts
+++ b/src/lib/authExpired.ts
@@ -1,10 +1,9 @@
-// Centralized 'session expired' handler. When any client-side call to a
-// server function or fetch returns 401 (cookie/JWT expired or missing), we
-// must (a) drop user-scoped caches so stale data from the previous session
-// isn't shown, (b) reset useAuth().user to null so the layout switches to
-// the logged-out landing, and (c) prompt the user to re-authenticate. We
-// use a custom DOM event to keep this module React-free; AuthProvider
-// listens for it and opens LoginModal.
+// Centralized 'session expired' handler. When the client detects an expired
+// or missing session cookie, we must (a) drop user-scoped caches so stale
+// data from the previous session isn't shown, (b) reset useAuth().user to
+// null so the layout switches to the logged-out landing, and (c) prompt the
+// user to re-authenticate. We use a custom DOM event to keep this module
+// React-free; AuthProvider listens for it and opens LoginModal.
 
 import type { QueryClient } from '@tanstack/react-query'
 import { clearUserScopedCache } from './auth'

--- a/src/lib/chatCache.ts
+++ b/src/lib/chatCache.ts
@@ -74,7 +74,7 @@ export async function startChatStream({
 
     if (!response.ok) {
       if (response.status === 401) {
-        handleAuthExpired(queryClient)
+        handleAuthExpired()
       }
       throw new Error(`ADK request failed: HTTP ${response.status}`)
     }

--- a/src/lib/chatCache.ts
+++ b/src/lib/chatCache.ts
@@ -1,4 +1,5 @@
 import type { QueryClient } from '@tanstack/react-query'
+import { handleAuthExpired } from './authExpired'
 import type {
   AdkEvent,
   AdkSession,
@@ -72,6 +73,9 @@ export async function startChatStream({
     })
 
     if (!response.ok) {
+      if (response.status === 401) {
+        handleAuthExpired(queryClient)
+      }
       throw new Error(`ADK request failed: HTTP ${response.status}`)
     }
 

--- a/src/lib/chatSessions.functions.ts
+++ b/src/lib/chatSessions.functions.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from '@tanstack/react-start'
-import { ADK_APP_NAME, ADK_USER_ID, adkClient } from './adkClient'
+import { ADK_APP_NAME, adkClient } from './adkClient'
 import { handleAdkError, handleAdkResponseError } from './adk-errors'
+import { resolveAdkUserIdOrThrow } from '@/server/adkUser'
 
 const SESSION_TITLE_KEY = 'title'
 
@@ -22,11 +23,12 @@ export interface SessionListItem {
 
 export const listSessions = createServerFn({ method: 'GET' }).handler(
   async () => {
+    const userId = await resolveAdkUserIdOrThrow()
     const { data, error } = await adkClient.GET(
       '/apps/{app_name}/users/{user_id}/sessions',
       {
         params: {
-          path: { app_name: ADK_APP_NAME, user_id: ADK_USER_ID },
+          path: { app_name: ADK_APP_NAME, user_id: userId },
         },
       },
     )
@@ -58,13 +60,14 @@ export const listSessions = createServerFn({ method: 'GET' }).handler(
 export const getSession = createServerFn({ method: 'GET' })
   .inputValidator((sessionId: string) => sessionId)
   .handler(async ({ data: sessionId }) => {
+    const userId = await resolveAdkUserIdOrThrow()
     const { data, error } = await adkClient.GET(
       '/apps/{app_name}/users/{user_id}/sessions/{session_id}',
       {
         params: {
           path: {
             app_name: ADK_APP_NAME,
-            user_id: ADK_USER_ID,
+            user_id: userId,
             session_id: sessionId,
           },
         },
@@ -82,13 +85,14 @@ interface CreateSessionInput {
 export const createSession = createServerFn({ method: 'POST' })
   .inputValidator((input: CreateSessionInput) => input)
   .handler(async ({ data: { sessionId, name } }) => {
+    const userId = await resolveAdkUserIdOrThrow()
     const { response } = await adkClient.POST(
       '/apps/{app_name}/users/{user_id}/sessions/{session_id}',
       {
         params: {
           path: {
             app_name: ADK_APP_NAME,
-            user_id: ADK_USER_ID,
+            user_id: userId,
             session_id: sessionId,
           },
         },
@@ -118,13 +122,14 @@ interface UpdateSessionInput {
 export const updateSessionTitle = createServerFn({ method: 'POST' })
   .inputValidator((input: UpdateSessionInput) => input)
   .handler(async ({ data: { sessionId, title } }) => {
+    const userId = await resolveAdkUserIdOrThrow()
     const { data, error } = await adkClient.PATCH(
       '/apps/{app_name}/users/{user_id}/sessions/{session_id}',
       {
         params: {
           path: {
             app_name: ADK_APP_NAME,
-            user_id: ADK_USER_ID,
+            user_id: userId,
             session_id: sessionId,
           },
         },
@@ -140,13 +145,14 @@ export const updateSessionTitle = createServerFn({ method: 'POST' })
 export const markSessionOpened = createServerFn({ method: 'POST' })
   .inputValidator((sessionId: string) => sessionId)
   .handler(async ({ data: sessionId }) => {
+    const userId = await resolveAdkUserIdOrThrow()
     const { error } = await adkClient.PATCH(
       '/apps/{app_name}/users/{user_id}/sessions/{session_id}',
       {
         params: {
           path: {
             app_name: ADK_APP_NAME,
-            user_id: ADK_USER_ID,
+            user_id: userId,
             session_id: sessionId,
           },
         },

--- a/src/lib/cofactsExec.ts
+++ b/src/lib/cofactsExec.ts
@@ -4,8 +4,8 @@
 // queries work — and forwards the JWT as Bearer auth.
 //
 // On network error, non-2xx response, or GraphQL `errors` array, this throws.
-// Callers that want a soft-fail (e.g. `getCurrentUserServerFn` returning null
-// when the user isn't logged in) wrap the call in try/catch.
+// Callers that want a soft-fail wrap the call in try/catch and handle null /
+// partial data themselves.
 //
 // Server-only: depends on h3's getCookie via @tanstack/react-start/server. Do
 // not import from client code.

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,20 +1,32 @@
-import { QueryClient } from '@tanstack/react-query'
+import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query'
 import { createRouter } from '@tanstack/react-router'
 import { setupRouterSsrQueryIntegration } from '@tanstack/react-router-ssr-query'
 
 import { routeTree } from './routeTree.gen'
+import {
+  handleAuthExpired,
+  isAuthExpiredError,
+} from './lib/authExpired'
 
-// Create a fresh router + QueryClient per request. Keeping the QueryClient
-// module-scoped would let one user's SSR-populated cache (e.g. ['me']) leak
-// into the next request's render under Nitro's long-lived process.
 export const getRouter = () => {
-  const queryClient = new QueryClient({
+  // Fresh router + QueryClient per request: a module-scoped QueryClient would
+  // let one user's SSR-populated cache (e.g. ['me']) leak into the next
+  // request's render under Nitro's long-lived process.
+  let queryClient: QueryClient
+  const onError = (err: unknown) => {
+    if (isAuthExpiredError(err)) {
+      handleAuthExpired(queryClient)
+    }
+  }
+  queryClient = new QueryClient({
     defaultOptions: {
       queries: {
         staleTime: Infinity,
         gcTime: Infinity,
       },
     },
+    queryCache: new QueryCache({ onError }),
+    mutationCache: new MutationCache({ onError }),
   })
 
   const router = createRouter({

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -3,22 +3,18 @@ import { createRouter } from '@tanstack/react-router'
 import { setupRouterSsrQueryIntegration } from '@tanstack/react-router-ssr-query'
 
 import { routeTree } from './routeTree.gen'
-import {
-  handleAuthExpired,
-  isAuthExpiredError,
-} from './lib/authExpired'
+import { handleAuthExpired, isAuthExpiredError } from './lib/authExpired'
 
 export const getRouter = () => {
   // Fresh router + QueryClient per request: a module-scoped QueryClient would
   // let one user's SSR-populated cache (e.g. ['me']) leak into the next
   // request's render under Nitro's long-lived process.
-  let queryClient: QueryClient
   const onError = (err: unknown) => {
     if (isAuthExpiredError(err)) {
-      handleAuthExpired(queryClient)
+      handleAuthExpired()
     }
   }
-  queryClient = new QueryClient({
+  const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
         staleTime: Infinity,

--- a/src/routes/_app.tsx
+++ b/src/routes/_app.tsx
@@ -2,6 +2,8 @@ import { Outlet, createFileRoute } from '@tanstack/react-router'
 import { useCallback, useState } from 'react'
 import { Sidebar } from '@/components/Sidebar'
 import { Header } from '@/components/Header'
+import { LoggedOutLanding } from '@/components/LoggedOutLanding'
+import { useAuth } from '@/lib/auth'
 
 export const Route = createFileRoute('/_app')({
   component: AppLayout,
@@ -9,6 +11,7 @@ export const Route = createFileRoute('/_app')({
 
 function AppLayout() {
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const { user } = useAuth()
 
   const toggleSidebar = useCallback(() => setSidebarOpen((v) => !v), [])
 
@@ -19,13 +22,22 @@ function AppLayout() {
 
       {/* Main content */}
       <main className="flex-1 flex overflow-hidden">
-        {/* Sidebar - Desktop: always visible, Mobile: overlay */}
-        <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+        {!user ? (
+          <LoggedOutLanding />
+        ) : (
+          <>
+            {/* Sidebar - Desktop: always visible, Mobile: overlay */}
+            <Sidebar
+              isOpen={sidebarOpen}
+              onClose={() => setSidebarOpen(false)}
+            />
 
-        {/* Chat Area (center) */}
-        <section className="flex-1 flex flex-col bg-white min-w-0 relative overflow-hidden">
-          <Outlet />
-        </section>
+            {/* Chat Area (center) */}
+            <section className="flex-1 flex flex-col bg-white min-w-0 relative overflow-hidden">
+              <Outlet />
+            </section>
+          </>
+        )}
       </main>
     </div>
   )

--- a/src/routes/_app/index.tsx
+++ b/src/routes/_app/index.tsx
@@ -1,11 +1,10 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useCallback, useState } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
+import { useQueryClient, useMutation } from '@tanstack/react-query'
 import { sendChatMessage } from '@/lib/chatCache'
 import { createSession } from '@/lib/chatSessions.functions'
 import { ChatInput } from '@/components/ChatInput'
 import { WelcomeHero } from '@/components/WelcomeHero'
-import { handleAuthExpired, isAuthExpiredError } from '@/lib/authExpired'
+import { isAuthExpiredError } from '@/lib/authExpired'
 
 export const Route = createFileRoute('/_app/')({
   component: LandingPage,
@@ -14,62 +13,41 @@ export const Route = createFileRoute('/_app/')({
 function LandingPage() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
 
-  const handleSend = useCallback(
-    async (text: string) => {
-      if (isLoading) return
-
-      setIsLoading(true)
-      setError(null)
-
+  const sendMutation = useMutation({
+    mutationFn: async (text: string) => {
       const sessionId = crypto.randomUUID()
-
-      // Generate session title from the first message
       const title = text.length > 40 ? text.slice(0, 40) + '...' : text
-
-      // 1. Create the session in ADK upfront
-      try {
-        await createSession({
-          data: {
-            sessionId,
-            name: title,
-          },
-        })
-      } catch (err) {
-        if (isAuthExpiredError(err)) {
-          handleAuthExpired(queryClient)
-          setIsLoading(false)
-          return
-        }
-        setError(err instanceof Error ? err.message : '建立工作階段失敗')
-        setIsLoading(false)
-        return
-      }
-
-      queryClient.invalidateQueries({ queryKey: ['sessions'] })
-
-      // 2. Instantly seed the cache and start the background stream fetch
-      sendChatMessage(queryClient, sessionId, text)
-
-      navigate({
-        to: '/session/$sessionId',
-        params: { sessionId },
-      })
+      await createSession({ data: { sessionId, name: title } })
+      return { sessionId, text }
     },
-    [isLoading, navigate, queryClient],
-  )
+    onSuccess: ({ sessionId, text }) => {
+      queryClient.invalidateQueries({ queryKey: ['sessions'] })
+      sendChatMessage(queryClient, sessionId, text)
+      navigate({ to: '/session/$sessionId', params: { sessionId } })
+    },
+  })
+
+  // AUTH_EXPIRED errors surface as a LoginModal via the global MutationCache
+  // onError; the inline banner only renders non-auth failures.
+  const inlineError =
+    sendMutation.error && !isAuthExpiredError(sendMutation.error)
+      ? sendMutation.error instanceof Error
+        ? sendMutation.error.message
+        : '建立工作階段失敗'
+      : null
 
   return (
     <WelcomeHero>
       <ChatInput
-        onSend={handleSend}
-        disabled={isLoading}
+        onSend={(text) => sendMutation.mutate(text)}
+        disabled={sendMutation.isPending}
         placeholder="貼上想查核的訊息，或輸入 Cofacts 文章連結 (https://cofacts.tw/article/...)..."
       />
-      {error && (
-        <div className="mt-2 text-sm text-red-500 text-center">{error}</div>
+      {inlineError && (
+        <div className="mt-2 text-sm text-red-500 text-center">
+          {inlineError}
+        </div>
       )}
     </WelcomeHero>
   )

--- a/src/routes/_app/index.tsx
+++ b/src/routes/_app/index.tsx
@@ -4,8 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { sendChatMessage } from '@/lib/chatCache'
 import { createSession } from '@/lib/chatSessions.functions'
 import { ChatInput } from '@/components/ChatInput'
-import { LoginPrompt } from '@/components/LoginPrompt'
-import { useAuth } from '@/lib/auth'
+import { WelcomeHero } from '@/components/WelcomeHero'
 
 export const Route = createFileRoute('/_app/')({
   component: LandingPage,
@@ -14,7 +13,6 @@ export const Route = createFileRoute('/_app/')({
 function LandingPage() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const { user } = useAuth()
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -58,39 +56,15 @@ function LandingPage() {
   )
 
   return (
-    <div className="flex-1 flex flex-col items-center justify-center p-6">
-      {/* Welcome */}
-      <div className="max-w-2xl w-full text-center space-y-6">
-        <div className="w-16 h-16 bg-primary rounded-full flex items-center justify-center text-white font-bold text-2xl mx-auto shadow-lg">
-          C
-        </div>
-        <h1 className="text-2xl font-bold text-text-main">
-          歡迎使用 Cofacts.ai
-        </h1>
-        <p className="text-text-muted leading-relaxed">
-          貼上可疑訊息或 Cofacts 文章連結，AI 協助您進行查核、撰寫回應。
-        </p>
-      </div>
-
-      {/* Input */}
-      <div className="max-w-2xl w-full mt-8">
-        {user ? (
-          <>
-            <ChatInput
-              onSend={handleSend}
-              disabled={isLoading}
-              placeholder="貼上想查核的訊息，或輸入 Cofacts 文章連結 (https://cofacts.tw/article/...)..."
-            />
-            {error && (
-              <div className="mt-2 text-sm text-red-500 text-center">
-                {error}
-              </div>
-            )}
-          </>
-        ) : (
-          <LoginPrompt message="登入後即可開始與 Cofacts.ai 對話" />
-        )}
-      </div>
-    </div>
+    <WelcomeHero>
+      <ChatInput
+        onSend={handleSend}
+        disabled={isLoading}
+        placeholder="貼上想查核的訊息，或輸入 Cofacts 文章連結 (https://cofacts.tw/article/...)..."
+      />
+      {error && (
+        <div className="mt-2 text-sm text-red-500 text-center">{error}</div>
+      )}
+    </WelcomeHero>
   )
 }

--- a/src/routes/_app/index.tsx
+++ b/src/routes/_app/index.tsx
@@ -4,6 +4,8 @@ import { useQueryClient } from '@tanstack/react-query'
 import { sendChatMessage } from '@/lib/chatCache'
 import { createSession } from '@/lib/chatSessions.functions'
 import { ChatInput } from '@/components/ChatInput'
+import { LoginPrompt } from '@/components/LoginPrompt'
+import { useAuth } from '@/lib/auth'
 
 export const Route = createFileRoute('/_app/')({
   component: LandingPage,
@@ -12,6 +14,7 @@ export const Route = createFileRoute('/_app/')({
 function LandingPage() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const { user } = useAuth()
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -71,13 +74,21 @@ function LandingPage() {
 
       {/* Input */}
       <div className="max-w-2xl w-full mt-8">
-        <ChatInput
-          onSend={handleSend}
-          disabled={isLoading}
-          placeholder="貼上想查核的訊息，或輸入 Cofacts 文章連結 (https://cofacts.tw/article/...)..."
-        />
-        {error && (
-          <div className="mt-2 text-sm text-red-500 text-center">{error}</div>
+        {user ? (
+          <>
+            <ChatInput
+              onSend={handleSend}
+              disabled={isLoading}
+              placeholder="貼上想查核的訊息，或輸入 Cofacts 文章連結 (https://cofacts.tw/article/...)..."
+            />
+            {error && (
+              <div className="mt-2 text-sm text-red-500 text-center">
+                {error}
+              </div>
+            )}
+          </>
+        ) : (
+          <LoginPrompt message="登入後即可開始與 Cofacts.ai 對話" />
         )}
       </div>
     </div>

--- a/src/routes/_app/index.tsx
+++ b/src/routes/_app/index.tsx
@@ -5,6 +5,7 @@ import { sendChatMessage } from '@/lib/chatCache'
 import { createSession } from '@/lib/chatSessions.functions'
 import { ChatInput } from '@/components/ChatInput'
 import { WelcomeHero } from '@/components/WelcomeHero'
+import { handleAuthExpired, isAuthExpiredError } from '@/lib/authExpired'
 
 export const Route = createFileRoute('/_app/')({
   component: LandingPage,
@@ -37,6 +38,11 @@ function LandingPage() {
           },
         })
       } catch (err) {
+        if (isAuthExpiredError(err)) {
+          handleAuthExpired(queryClient)
+          setIsLoading(false)
+          return
+        }
         setError(err instanceof Error ? err.message : '建立工作階段失敗')
         setIsLoading(false)
         return

--- a/src/routes/_app/session.$sessionId.tsx
+++ b/src/routes/_app/session.$sessionId.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { ChatArea } from '@/components/ChatArea'
 import { useChat } from '@/hooks/useChat'
 import { markSessionOpened } from '@/lib/chatSessions.functions'
+import { handleAuthExpired, isAuthExpiredError } from '@/lib/authExpired'
 
 export const Route = createFileRoute('/_app/session/$sessionId')({
   component: SessionPage,
@@ -22,9 +23,13 @@ function SessionPage() {
       // otherwise when the stream ends, the session will be stale.
       return
     }
-    markSessionOpened({ data: sessionId }).then(() => {
-      queryClient.invalidateQueries({ queryKey: ['sessions'] })
-    })
+    markSessionOpened({ data: sessionId })
+      .then(() => {
+        queryClient.invalidateQueries({ queryKey: ['sessions'] })
+      })
+      .catch((err) => {
+        if (isAuthExpiredError(err)) handleAuthExpired(queryClient)
+      })
   }, [sessionId, queryClient, isStreaming])
 
   return (

--- a/src/routes/_app/session.$sessionId.tsx
+++ b/src/routes/_app/session.$sessionId.tsx
@@ -28,7 +28,7 @@ function SessionPage() {
         queryClient.invalidateQueries({ queryKey: ['sessions'] })
       })
       .catch((err) => {
-        if (isAuthExpiredError(err)) handleAuthExpired(queryClient)
+        if (isAuthExpiredError(err)) handleAuthExpired()
       })
   }, [sessionId, queryClient, isStreaming])
 

--- a/src/routes/api/run-sse.ts
+++ b/src/routes/api/run-sse.ts
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import type { components } from '@/lib/adk-types'
 import { ADK_APP_NAME, adkClient } from '@/lib/adkClient'
 import { handleAdkResponseError } from '@/lib/adk-errors'
+import { AUTH_EXPIRED_MESSAGE } from '@/lib/authExpired'
 import { resolveAdkUserIdOrThrow } from '@/server/adkUser'
 
 type RunRequest = components['schemas']['RunAgentRequest']
@@ -23,7 +24,15 @@ export const Route = createFileRoute('/api/run-sse')({
         try {
           userId = await resolveAdkUserIdOrThrow()
         } catch (err) {
-          if (err instanceof Response) return err
+          if (err instanceof Error && err.message === AUTH_EXPIRED_MESSAGE) {
+            return new Response(
+              JSON.stringify({ message: 'Authentication required' }),
+              {
+                status: 401,
+                headers: { 'Content-Type': 'application/json' },
+              },
+            )
+          }
           throw err
         }
 

--- a/src/routes/api/run-sse.ts
+++ b/src/routes/api/run-sse.ts
@@ -1,7 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { ADK_APP_NAME, ADK_USER_ID, adkClient } from '@/lib/adkClient'
-import { handleAdkResponseError } from '@/lib/adk-errors'
 import type { components } from '@/lib/adk-types'
+import { ADK_APP_NAME, adkClient } from '@/lib/adkClient'
+import { handleAdkResponseError } from '@/lib/adk-errors'
+import { UnauthorizedError, resolveAdkUserIdOrThrow } from '@/server/adkUser'
 
 type RunRequest = components['schemas']['RunAgentRequest']
 type ChatInput = Omit<RunRequest, 'appName' | 'userId' | 'streaming'>
@@ -18,6 +19,19 @@ export const Route = createFileRoute('/api/run-sse')({
   server: {
     handlers: {
       POST: async ({ request }) => {
+        let userId: string
+        try {
+          userId = await resolveAdkUserIdOrThrow()
+        } catch (err) {
+          if (err instanceof UnauthorizedError) {
+            return new Response(JSON.stringify({ error: err.message }), {
+              status: 401,
+              headers: { 'Content-Type': 'application/json' },
+            })
+          }
+          throw err
+        }
+
         const input = (await request.json()) as ChatInput
 
         const { response } = await adkClient.POST('/run_sse', {
@@ -25,7 +39,7 @@ export const Route = createFileRoute('/api/run-sse')({
           body: {
             ...input,
             appName: ADK_APP_NAME,
-            userId: ADK_USER_ID,
+            userId,
             streaming: true,
           },
           // When the client aborts the fetch, request.signal fires (via srvx),

--- a/src/routes/api/run-sse.ts
+++ b/src/routes/api/run-sse.ts
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import type { components } from '@/lib/adk-types'
 import { ADK_APP_NAME, adkClient } from '@/lib/adkClient'
 import { handleAdkResponseError } from '@/lib/adk-errors'
-import { UnauthorizedError, resolveAdkUserIdOrThrow } from '@/server/adkUser'
+import { resolveAdkUserIdOrThrow } from '@/server/adkUser'
 
 type RunRequest = components['schemas']['RunAgentRequest']
 type ChatInput = Omit<RunRequest, 'appName' | 'userId' | 'streaming'>
@@ -23,12 +23,7 @@ export const Route = createFileRoute('/api/run-sse')({
         try {
           userId = await resolveAdkUserIdOrThrow()
         } catch (err) {
-          if (err instanceof UnauthorizedError) {
-            return new Response(JSON.stringify({ error: err.message }), {
-              status: 401,
-              headers: { 'Content-Type': 'application/json' },
-            })
-          }
+          if (err instanceof Response) return err
           throw err
         }
 

--- a/src/server/__tests__/adkUser.test.ts
+++ b/src/server/__tests__/adkUser.test.ts
@@ -9,6 +9,7 @@ vi.mock('../jwt', () => ({
 }))
 
 import { getCookie } from '@tanstack/react-start/server'
+import { AUTH_EXPIRED_MESSAGE } from '@/lib/authExpired'
 import { verifySessionToken } from '../jwt'
 import { resolveAdkUserIdOrThrow } from '../adkUser'
 
@@ -34,40 +35,25 @@ describe('resolveAdkUserIdOrThrow', () => {
     expect(mockedVerify).toHaveBeenCalledWith('valid-token')
   })
 
-  test('throws a 401 Response when cookie is missing', async () => {
+  test('throws AUTH_EXPIRED Error when cookie is missing', async () => {
     mockedGetCookie.mockReturnValueOnce(undefined)
 
     await expect(resolveAdkUserIdOrThrow()).rejects.toSatisfy(
-      (err: unknown) => err instanceof Response && err.status === 401,
+      (err: unknown) =>
+        err instanceof Error && err.message === AUTH_EXPIRED_MESSAGE,
     )
     expect(mockedVerify).not.toHaveBeenCalled()
   })
 
-  test('throws a 401 Response when verify fails', async () => {
+  test('throws AUTH_EXPIRED Error when verify fails', async () => {
     mockedGetCookie.mockReturnValueOnce('bad-token')
     mockedVerify.mockRejectedValueOnce(
       new Error('signature verification failed'),
     )
 
     await expect(resolveAdkUserIdOrThrow()).rejects.toSatisfy(
-      (err: unknown) => err instanceof Response && err.status === 401,
+      (err: unknown) =>
+        err instanceof Error && err.message === AUTH_EXPIRED_MESSAGE,
     )
-  })
-
-  test('the thrown 401 Response carries a JSON message body', async () => {
-    mockedGetCookie.mockReturnValueOnce(undefined)
-
-    let thrown: unknown
-    try {
-      await resolveAdkUserIdOrThrow()
-    } catch (err) {
-      thrown = err
-    }
-
-    expect(thrown).toBeInstanceOf(Response)
-    const response = thrown as Response
-    expect(response.headers.get('Content-Type')).toBe('application/json')
-    const body = (await response.json()) as { message?: string }
-    expect(body.message).toBeTypeOf('string')
   })
 })

--- a/src/server/__tests__/adkUser.test.ts
+++ b/src/server/__tests__/adkUser.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('@tanstack/react-start/server', () => ({
+  getCookie: vi.fn(),
+}))
+
+vi.mock('../jwt', () => ({
+  verifySessionToken: vi.fn(),
+}))
+
+import { getCookie } from '@tanstack/react-start/server'
+import { verifySessionToken } from '../jwt'
+import { resolveAdkUserIdOrThrow } from '../adkUser'
+
+const mockedGetCookie = vi.mocked(getCookie)
+const mockedVerify = vi.mocked(verifySessionToken)
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('resolveAdkUserIdOrThrow', () => {
+  test('returns the user id when session cookie verifies', async () => {
+    mockedGetCookie.mockReturnValueOnce('valid-token')
+    mockedVerify.mockResolvedValueOnce({
+      userId: 'user-1',
+      issuedAt: 1,
+      expiresAt: 2,
+    })
+
+    const id = await resolveAdkUserIdOrThrow()
+
+    expect(id).toBe('user-1')
+    expect(mockedVerify).toHaveBeenCalledWith('valid-token')
+  })
+
+  test('throws a 401 Response when cookie is missing', async () => {
+    mockedGetCookie.mockReturnValueOnce(undefined)
+
+    await expect(resolveAdkUserIdOrThrow()).rejects.toSatisfy(
+      (err: unknown) => err instanceof Response && err.status === 401,
+    )
+    expect(mockedVerify).not.toHaveBeenCalled()
+  })
+
+  test('throws a 401 Response when verify fails', async () => {
+    mockedGetCookie.mockReturnValueOnce('bad-token')
+    mockedVerify.mockRejectedValueOnce(
+      new Error('signature verification failed'),
+    )
+
+    await expect(resolveAdkUserIdOrThrow()).rejects.toSatisfy(
+      (err: unknown) => err instanceof Response && err.status === 401,
+    )
+  })
+
+  test('the thrown 401 Response carries a JSON message body', async () => {
+    mockedGetCookie.mockReturnValueOnce(undefined)
+
+    let thrown: unknown
+    try {
+      await resolveAdkUserIdOrThrow()
+    } catch (err) {
+      thrown = err
+    }
+
+    expect(thrown).toBeInstanceOf(Response)
+    const response = thrown as Response
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+    const body = (await response.json()) as { message?: string }
+    expect(body.message).toBeTypeOf('string')
+  })
+})

--- a/src/server/__tests__/feedbackScores.test.ts
+++ b/src/server/__tests__/feedbackScores.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 import {
-  LangfuseFetchError,
   fetchFeedbackForTrace,
+  postFeedbackForTrace,
 } from '../feedbackScores.functions'
 
 const originalFetch = global.fetch
@@ -147,11 +147,96 @@ describe('fetchFeedbackForTrace', () => {
     expect(result.value).toBe(-1)
   })
 
-  test('throws LangfuseFetchError on upstream failure so the handler can map it to 502', async () => {
+  test('throws an Error with langfuse upstream message on failure', async () => {
     mockFetchOnce({ ok: false, status: 503, statusText: 'Service Unavailable' })
 
     await expect(
       fetchFeedbackForTrace('trace-1', 'user-1'),
-    ).rejects.toBeInstanceOf(LangfuseFetchError)
+    ).rejects.toSatisfy(
+      (err: unknown) =>
+        err instanceof Error &&
+        err.message === 'Langfuse upstream failed: 503 Service Unavailable',
+    )
+  })
+})
+
+describe('postFeedbackForTrace', () => {
+  test('no-ops when Langfuse env vars are missing', async () => {
+    delete process.env.LANGFUSE_BASE_URL
+    delete process.env.LANGFUSE_PUBLIC_KEY
+    delete process.env.LANGFUSE_SECRET_KEY
+    const fetchSpy = vi.fn()
+    global.fetch = fetchSpy as unknown as typeof fetch
+
+    await postFeedbackForTrace({ traceId: 'trace-1', value: 1 })
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  test('POSTs deterministic id, NUMERIC dataType, and Basic auth header', async () => {
+    const fetchSpy = mockFetchOnce({ jsonBody: { id: 'user-trace-1' } })
+
+    await postFeedbackForTrace({
+      traceId: 'trace-1',
+      value: 1,
+      comment: 'helpful',
+    })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [calledUrl, init] = fetchSpy.mock.calls[0] as [URL, RequestInit]
+    expect(calledUrl.pathname).toBe('/api/public/v2/scores')
+    expect(init.method).toBe('POST')
+    const headers = init.headers as Record<string, string>
+    expect(headers.Authorization).toBe(
+      `Basic ${Buffer.from('pk-test:sk-test').toString('base64')}`,
+    )
+    expect(headers['Content-Type']).toBe('application/json')
+    const body = JSON.parse(init.body as string)
+    expect(body).toEqual({
+      id: 'user-trace-1',
+      traceId: 'trace-1',
+      name: 'user-thumbs',
+      value: 1,
+      dataType: 'NUMERIC',
+      comment: 'helpful',
+    })
+  })
+
+  test('omits comment field when not provided so prior comment is preserved on toggle', async () => {
+    const fetchSpy = mockFetchOnce({ jsonBody: {} })
+
+    await postFeedbackForTrace({ traceId: 'trace-1', value: -1 })
+
+    const [, init] = fetchSpy.mock.calls[0] as [URL, RequestInit]
+    const body = JSON.parse(init.body as string)
+    expect(body).not.toHaveProperty('comment')
+    expect(body.value).toBe(-1)
+  })
+
+  test('sends value 0 to clear feedback', async () => {
+    const fetchSpy = mockFetchOnce({ jsonBody: {} })
+
+    await postFeedbackForTrace({
+      traceId: 'trace-1',
+      value: 0,
+      comment: '',
+    })
+
+    const [, init] = fetchSpy.mock.calls[0] as [URL, RequestInit]
+    const body = JSON.parse(init.body as string)
+    expect(body.value).toBe(0)
+    expect(body.comment).toBe('')
+  })
+
+  test('throws an Error with langfuse upstream message on failure', async () => {
+    mockFetchOnce({ ok: false, status: 500, statusText: 'Server Error' })
+
+    await expect(
+      postFeedbackForTrace({ traceId: 'trace-1', value: 1 }),
+    ).rejects.toSatisfy(
+      (err: unknown) =>
+        err instanceof Error &&
+        err.message === 'Langfuse upstream failed: 500 Server Error',
+    )
   })
 })

--- a/src/server/__tests__/feedbackScores.test.ts
+++ b/src/server/__tests__/feedbackScores.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  LangfuseFetchError,
+  fetchFeedbackForTrace,
+} from '../feedbackScores.functions'
+
+const originalFetch = global.fetch
+const originalEnv = { ...process.env }
+
+beforeEach(() => {
+  process.env.LANGFUSE_BASE_URL = 'https://langfuse.example.test'
+  process.env.LANGFUSE_PUBLIC_KEY = 'pk-test'
+  process.env.LANGFUSE_SECRET_KEY = 'sk-test'
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  global.fetch = originalFetch
+  process.env = { ...originalEnv }
+})
+
+function mockFetchOnce(response: Partial<Response> & { jsonBody?: unknown }) {
+  const fn = vi.fn(() =>
+    Promise.resolve({
+      ok: response.ok ?? true,
+      status: response.status ?? 200,
+      statusText: response.statusText ?? 'OK',
+      json: () => Promise.resolve(response.jsonBody ?? { data: [] }),
+    }),
+  ) as unknown as typeof fetch
+  global.fetch = fn
+  return fn as unknown as ReturnType<typeof vi.fn>
+}
+
+describe('fetchFeedbackForTrace', () => {
+  test('returns null score when Langfuse env vars are missing', async () => {
+    delete process.env.LANGFUSE_BASE_URL
+    delete process.env.LANGFUSE_PUBLIC_KEY
+    delete process.env.LANGFUSE_SECRET_KEY
+    const fetchSpy = vi.fn()
+    global.fetch = fetchSpy as unknown as typeof fetch
+
+    const result = await fetchFeedbackForTrace('trace-1', 'user-1')
+
+    expect(result).toEqual({ value: null, comment: null })
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  test('filters by trace.userId via query params and sends Basic auth header', async () => {
+    const fetchSpy = mockFetchOnce({ jsonBody: { data: [] } })
+
+    await fetchFeedbackForTrace('trace-abc', 'user-42')
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [calledUrl, init] = fetchSpy.mock.calls[0] as [URL, RequestInit]
+    expect(calledUrl.origin).toBe('https://langfuse.example.test')
+    expect(calledUrl.pathname).toBe('/api/public/v2/scores')
+    expect(calledUrl.searchParams.get('traceId')).toBe('trace-abc')
+    expect(calledUrl.searchParams.get('name')).toBe('user-thumbs')
+    expect(calledUrl.searchParams.get('userId')).toBe('user-42')
+    expect(calledUrl.searchParams.get('fields')).toBe('scores,trace')
+    expect(calledUrl.searchParams.get('filter')).toBeNull()
+    const auth = (init.headers as Record<string, string>).Authorization
+    expect(auth).toBe(
+      `Basic ${Buffer.from('pk-test:sk-test').toString('base64')}`,
+    )
+  })
+
+  test('returns null score when Langfuse has no matching scores', async () => {
+    mockFetchOnce({ jsonBody: { data: [] } })
+
+    const result = await fetchFeedbackForTrace('trace-1', 'user-1')
+
+    expect(result).toEqual({ value: null, comment: null })
+  })
+
+  test('returns thumbs-up with comment from latest score', async () => {
+    mockFetchOnce({
+      jsonBody: {
+        data: [
+          {
+            id: 'user-trace-1',
+            name: 'user-thumbs',
+            value: 1,
+            comment: 'helpful',
+            updatedAt: '2026-01-02T00:00:00Z',
+            createdAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      },
+    })
+
+    const result = await fetchFeedbackForTrace('trace-1', 'user-1')
+
+    expect(result).toEqual({ value: 1, comment: 'helpful' })
+  })
+
+  test('maps cleared score (value 0) to null so the UI shows no selection', async () => {
+    mockFetchOnce({
+      jsonBody: {
+        data: [
+          {
+            id: 'user-trace-1',
+            name: 'user-thumbs',
+            value: 0,
+            comment: '',
+            updatedAt: '2026-01-02T00:00:00Z',
+          },
+        ],
+      },
+    })
+
+    const result = await fetchFeedbackForTrace('trace-1', 'user-1')
+
+    expect(result).toEqual({ value: null, comment: '' })
+  })
+
+  test('picks the most recently updated score when multiple are returned', async () => {
+    mockFetchOnce({
+      jsonBody: {
+        data: [
+          {
+            id: 'a',
+            name: 'user-thumbs',
+            value: 1,
+            updatedAt: '2026-01-01T00:00:00Z',
+          },
+          {
+            id: 'b',
+            name: 'user-thumbs',
+            value: -1,
+            updatedAt: '2026-01-03T00:00:00Z',
+          },
+          {
+            id: 'c',
+            name: 'user-thumbs',
+            value: 1,
+            updatedAt: '2026-01-02T00:00:00Z',
+          },
+        ],
+      },
+    })
+
+    const result = await fetchFeedbackForTrace('trace-1', 'user-1')
+
+    expect(result.value).toBe(-1)
+  })
+
+  test('throws LangfuseFetchError on upstream failure so the handler can map it to 502', async () => {
+    mockFetchOnce({ ok: false, status: 503, statusText: 'Service Unavailable' })
+
+    await expect(
+      fetchFeedbackForTrace('trace-1', 'user-1'),
+    ).rejects.toBeInstanceOf(LangfuseFetchError)
+  })
+})

--- a/src/server/__tests__/jwt.test.ts
+++ b/src/server/__tests__/jwt.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('jose', () => ({
+  jwtVerify: vi.fn(),
+}))
+
+vi.mock('../jwks', () => ({
+  getJWKS: vi.fn(() => 'mock-jwks-resolver'),
+}))
+
+describe('verifySessionToken', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  test('returns userId/issuedAt/expiresAt on valid token and pins RS256', async () => {
+    const { jwtVerify } = await import('jose')
+    const { getJWKS } = await import('../jwks')
+    vi.mocked(jwtVerify).mockResolvedValueOnce({
+      payload: { sub: 'u1', iat: 1700000000, exp: 1701000000 },
+      protectedHeader: { alg: 'RS256' },
+    } as never)
+
+    const { verifySessionToken } = await import('../jwt')
+    const result = await verifySessionToken('tok')
+
+    expect(result).toEqual({
+      userId: 'u1',
+      issuedAt: 1700000000,
+      expiresAt: 1701000000,
+    })
+    expect(jwtVerify).toHaveBeenCalledWith(
+      'tok',
+      vi.mocked(getJWKS).mock.results[0].value,
+      { algorithms: ['RS256'] },
+    )
+  })
+
+  test('throws when sub claim is missing', async () => {
+    const { jwtVerify } = await import('jose')
+    vi.mocked(jwtVerify).mockResolvedValueOnce({
+      payload: { iat: 1, exp: 2 },
+      protectedHeader: { alg: 'RS256' },
+    } as never)
+
+    const { verifySessionToken } = await import('../jwt')
+    await expect(verifySessionToken('tok')).rejects.toThrow(
+      'JWT missing sub claim',
+    )
+  })
+
+  test('throws when iat or exp is missing', async () => {
+    const { jwtVerify } = await import('jose')
+    vi.mocked(jwtVerify).mockResolvedValueOnce({
+      payload: { sub: 'u1' },
+      protectedHeader: { alg: 'RS256' },
+    } as never)
+
+    const { verifySessionToken } = await import('../jwt')
+    await expect(verifySessionToken('tok')).rejects.toThrow(
+      'JWT missing iat/exp claims',
+    )
+  })
+
+  test('propagates errors from jwtVerify (invalid sig / expired)', async () => {
+    const { jwtVerify } = await import('jose')
+    vi.mocked(jwtVerify).mockRejectedValueOnce(
+      new Error('signature verification failed'),
+    )
+
+    const { verifySessionToken } = await import('../jwt')
+    await expect(verifySessionToken('tok')).rejects.toThrow(
+      'signature verification failed',
+    )
+  })
+})

--- a/src/server/adkUser.ts
+++ b/src/server/adkUser.ts
@@ -3,32 +3,23 @@
 // `GetUser` round-trip (which is rate-limited). Falls through to 401 on missing
 // cookie or any verify failure (bad signature, expired, wrong alg, missing claims).
 //
-// Auth failure throws `Response`: TanStack Start's serverFn handler passes
-// thrown Response objects through verbatim, and the client deserializer hands
-// the same Response to the caller, so HTTP status survives the RPC boundary.
+// Auth failure throws `new Error(AUTH_EXPIRED_MESSAGE)` so the serverFn
+// client re-throws it on the caller side, letting React Query's onError fire
+// and the global auth-expired handler prompt re-login.
 
 import { getCookie } from '@tanstack/react-start/server'
 
+import { AUTH_EXPIRED_MESSAGE } from '@/lib/authExpired'
 import { SESSION_COOKIE_NAME } from './sessionCookie'
 import { verifySessionToken } from './jwt'
 
-function unauthorized(): Response {
-  return new Response(
-    JSON.stringify({ message: 'Authentication required' }),
-    {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    },
-  )
-}
-
 export async function resolveAdkUserIdOrThrow(): Promise<string> {
   const token = getCookie(SESSION_COOKIE_NAME)
-  if (!token) throw unauthorized()
+  if (!token) throw new Error(AUTH_EXPIRED_MESSAGE)
   try {
     const { userId } = await verifySessionToken(token)
     return userId
   } catch {
-    throw unauthorized()
+    throw new Error(AUTH_EXPIRED_MESSAGE)
   }
 }

--- a/src/server/adkUser.ts
+++ b/src/server/adkUser.ts
@@ -1,23 +1,34 @@
-// Server-side helper that resolves the current user's Cofacts ID for use as
-// the ADK `user_id` path/body parameter. Reads the HttpOnly cofacts_session
-// cookie (via cofactsExec) and dispatches GetCurrentUser. Throws a 401-shaped
-// Response when no authenticated user is present so callers can let the
-// framework propagate it back to the browser.
+// Resolves the current user's Cofacts ID for the ADK `user_id` parameter by
+// verifying the BFF session cookie JWT locally — avoids a per-request rumors-api
+// `GetUser` round-trip (which is rate-limited). Falls through to 401 on missing
+// cookie or any verify failure (bad signature, expired, wrong alg, missing claims).
+//
+// Auth failure throws `Response`: TanStack Start's serverFn handler passes
+// thrown Response objects through verbatim, and the client deserializer hands
+// the same Response to the caller, so HTTP status survives the RPC boundary.
 
-import { getCurrentUserServerFn } from './me.functions'
+import { getCookie } from '@tanstack/react-start/server'
 
-export class UnauthorizedError extends Error {
-  readonly status = 401
-  constructor(message = 'Authentication required') {
-    super(message)
-    this.name = 'UnauthorizedError'
-  }
+import { SESSION_COOKIE_NAME } from './sessionCookie'
+import { verifySessionToken } from './jwt'
+
+function unauthorized(): Response {
+  return new Response(
+    JSON.stringify({ message: 'Authentication required' }),
+    {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    },
+  )
 }
 
 export async function resolveAdkUserIdOrThrow(): Promise<string> {
-  const user = await getCurrentUserServerFn()
-  if (!user) {
-    throw new UnauthorizedError()
+  const token = getCookie(SESSION_COOKIE_NAME)
+  if (!token) throw unauthorized()
+  try {
+    const { userId } = await verifySessionToken(token)
+    return userId
+  } catch {
+    throw unauthorized()
   }
-  return user.id
 }

--- a/src/server/adkUser.ts
+++ b/src/server/adkUser.ts
@@ -1,0 +1,23 @@
+// Server-side helper that resolves the current user's Cofacts ID for use as
+// the ADK `user_id` path/body parameter. Reads the HttpOnly cofacts_session
+// cookie (via cofactsExec) and dispatches GetCurrentUser. Throws a 401-shaped
+// Response when no authenticated user is present so callers can let the
+// framework propagate it back to the browser.
+
+import { getCurrentUserServerFn } from './me.functions'
+
+export class UnauthorizedError extends Error {
+  readonly status = 401
+  constructor(message = 'Authentication required') {
+    super(message)
+    this.name = 'UnauthorizedError'
+  }
+}
+
+export async function resolveAdkUserIdOrThrow(): Promise<string> {
+  const user = await getCurrentUserServerFn()
+  if (!user) {
+    throw new UnauthorizedError()
+  }
+  return user.id
+}

--- a/src/server/feedbackScores.functions.ts
+++ b/src/server/feedbackScores.functions.ts
@@ -1,5 +1,4 @@
 import { createServerFn } from '@tanstack/react-start'
-import { setResponseStatus } from '@tanstack/react-start/server'
 import { resolveAdkUserIdOrThrow } from './adkUser'
 
 const SCORE_NAME = 'user-thumbs'
@@ -9,14 +8,8 @@ export interface FeedbackScore {
   comment: string | null
 }
 
-export class LangfuseFetchError extends Error {
-  constructor(
-    public readonly status: number,
-    public readonly statusText: string,
-  ) {
-    super(`Langfuse scores fetch failed: ${status} ${statusText}`)
-    this.name = 'LangfuseFetchError'
-  }
+function langfuseUpstreamFailed(status: number, statusText: string): Error {
+  return new Error(`Langfuse upstream failed: ${status} ${statusText}`)
 }
 
 interface LangfuseScore {
@@ -75,7 +68,7 @@ export async function fetchFeedbackForTrace(
     headers: { Authorization: `Basic ${auth}` },
   })
   if (!response.ok) {
-    throw new LangfuseFetchError(response.status, response.statusText)
+    throw langfuseUpstreamFailed(response.status, response.statusText)
   }
   const body = (await response.json()) as LangfuseScoresResponse
 
@@ -91,12 +84,70 @@ export const getFeedbackForTrace = createServerFn({ method: 'GET' })
   .inputValidator((traceId: string) => traceId)
   .handler(async ({ data: traceId }): Promise<FeedbackScore> => {
     const userId = await resolveAdkUserIdOrThrow()
-    try {
-      return await fetchFeedbackForTrace(traceId, userId)
-    } catch (err) {
-      if (err instanceof LangfuseFetchError) {
-        setResponseStatus(502)
-      }
-      throw err
+    return await fetchFeedbackForTrace(traceId, userId)
+  })
+
+export interface SubmitFeedbackInput {
+  traceId: string
+  value: 1 | -1 | 0
+  comment?: string
+}
+
+function isSubmitFeedbackInput(raw: unknown): raw is SubmitFeedbackInput {
+  if (!raw || typeof raw !== 'object') return false
+  const obj = raw as Record<string, unknown>
+  if (typeof obj.traceId !== 'string' || obj.traceId.length === 0) return false
+  if (obj.value !== 1 && obj.value !== -1 && obj.value !== 0) return false
+  if (obj.comment !== undefined && typeof obj.comment !== 'string') return false
+  return true
+}
+
+export async function postFeedbackForTrace(
+  input: SubmitFeedbackInput,
+): Promise<void> {
+  const baseUrl = process.env.LANGFUSE_BASE_URL
+  const publicKey = process.env.LANGFUSE_PUBLIC_KEY
+  const secretKey = process.env.LANGFUSE_SECRET_KEY
+  if (!baseUrl || !publicKey || !secretKey) return
+
+  const url = new URL('/api/public/v2/scores', baseUrl)
+  const auth = Buffer.from(`${publicKey}:${secretKey}`).toString('base64')
+  // Deterministic id makes repeated submissions for the same trace upsert
+  // (Langfuse merges scores by id within the project), so toggling thumbs
+  // overwrites the previous value instead of accumulating duplicates.
+  const body: Record<string, unknown> = {
+    id: `user-${input.traceId}`,
+    traceId: input.traceId,
+    name: SCORE_NAME,
+    value: input.value,
+    dataType: 'NUMERIC',
+  }
+  if (input.comment !== undefined) body.comment = input.comment
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${auth}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+  if (!response.ok) {
+    throw langfuseUpstreamFailed(response.status, response.statusText)
+  }
+}
+
+export const submitFeedbackForTrace = createServerFn({ method: 'POST' })
+  .inputValidator((raw: unknown): SubmitFeedbackInput => {
+    if (!isSubmitFeedbackInput(raw)) {
+      throw new Error('Invalid feedback submission payload')
     }
+    return raw
+  })
+  .handler(async ({ data }): Promise<{ ok: true }> => {
+    // Re-resolve identity per submission so an expired cookie/JWT triggers
+    // a 401 here instead of silently posting under a stale user id.
+    await resolveAdkUserIdOrThrow()
+    await postFeedbackForTrace(data)
+    return { ok: true }
   })

--- a/src/server/feedbackScores.functions.ts
+++ b/src/server/feedbackScores.functions.ts
@@ -93,15 +93,6 @@ export interface SubmitFeedbackInput {
   comment?: string
 }
 
-function isSubmitFeedbackInput(raw: unknown): raw is SubmitFeedbackInput {
-  if (!raw || typeof raw !== 'object') return false
-  const obj = raw as Record<string, unknown>
-  if (typeof obj.traceId !== 'string' || obj.traceId.length === 0) return false
-  if (obj.value !== 1 && obj.value !== -1 && obj.value !== 0) return false
-  if (obj.comment !== undefined && typeof obj.comment !== 'string') return false
-  return true
-}
-
 export async function postFeedbackForTrace(
   input: SubmitFeedbackInput,
 ): Promise<void> {
@@ -138,12 +129,7 @@ export async function postFeedbackForTrace(
 }
 
 export const submitFeedbackForTrace = createServerFn({ method: 'POST' })
-  .inputValidator((raw: unknown): SubmitFeedbackInput => {
-    if (!isSubmitFeedbackInput(raw)) {
-      throw new Error('Invalid feedback submission payload')
-    }
-    return raw
-  })
+  .inputValidator((raw: SubmitFeedbackInput) => raw)
   .handler(async ({ data }): Promise<{ ok: true }> => {
     // Re-resolve identity per submission so an expired cookie/JWT triggers
     // a 401 here instead of silently posting under a stale user id.

--- a/src/server/feedbackScores.functions.ts
+++ b/src/server/feedbackScores.functions.ts
@@ -1,0 +1,102 @@
+import { createServerFn } from '@tanstack/react-start'
+import { setResponseStatus } from '@tanstack/react-start/server'
+import { resolveAdkUserIdOrThrow } from './adkUser'
+
+const SCORE_NAME = 'user-thumbs'
+
+export interface FeedbackScore {
+  value: 1 | -1 | null
+  comment: string | null
+}
+
+export class LangfuseFetchError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+  ) {
+    super(`Langfuse scores fetch failed: ${status} ${statusText}`)
+    this.name = 'LangfuseFetchError'
+  }
+}
+
+interface LangfuseScore {
+  id: string
+  name: string
+  value?: number
+  comment?: string | null
+  metadata?: unknown
+  createdAt?: string
+  updatedAt?: string
+}
+
+interface LangfuseScoresResponse {
+  data?: Array<LangfuseScore>
+}
+
+export function normalizeValue(raw: number | undefined): 1 | -1 | null {
+  if (raw === 1) return 1
+  if (raw === -1) return -1
+  return null
+}
+
+export function pickLatest(
+  scores: Array<LangfuseScore>,
+): LangfuseScore | null {
+  return scores.reduce<LangfuseScore | null>((acc, score) => {
+    if (!acc) return score
+    const accTime = acc.updatedAt ?? acc.createdAt ?? ''
+    const curTime = score.updatedAt ?? score.createdAt ?? ''
+    return curTime > accTime ? score : acc
+  }, null)
+}
+
+export async function fetchFeedbackForTrace(
+  traceId: string,
+  userId: string,
+): Promise<FeedbackScore> {
+  const baseUrl = process.env.LANGFUSE_BASE_URL
+  const publicKey = process.env.LANGFUSE_PUBLIC_KEY
+  const secretKey = process.env.LANGFUSE_SECRET_KEY
+  if (!baseUrl || !publicKey || !secretKey) {
+    return { value: null, comment: null }
+  }
+
+  const url = new URL('/api/public/v2/scores', baseUrl)
+  url.searchParams.set('traceId', traceId)
+  url.searchParams.set('name', SCORE_NAME)
+  // userId filters server-side by trace.userId; requires 'trace' in fields
+  // per Langfuse v2 API contract.
+  url.searchParams.set('userId', userId)
+  url.searchParams.set('fields', 'scores,trace')
+  url.searchParams.set('limit', '50')
+
+  const auth = Buffer.from(`${publicKey}:${secretKey}`).toString('base64')
+  const response = await fetch(url, {
+    headers: { Authorization: `Basic ${auth}` },
+  })
+  if (!response.ok) {
+    throw new LangfuseFetchError(response.status, response.statusText)
+  }
+  const body = (await response.json()) as LangfuseScoresResponse
+
+  const latest = pickLatest(body.data ?? [])
+  if (!latest) return { value: null, comment: null }
+  return {
+    value: normalizeValue(latest.value),
+    comment: latest.comment ?? null,
+  }
+}
+
+export const getFeedbackForTrace = createServerFn({ method: 'GET' })
+  .inputValidator((traceId: string) => traceId)
+  .handler(async ({ data: traceId }): Promise<FeedbackScore> => {
+    const userId = await resolveAdkUserIdOrThrow()
+    try {
+      return await fetchFeedbackForTrace(traceId, userId)
+    } catch (err) {
+      if (err instanceof LangfuseFetchError) {
+        setResponseStatus(502)
+      }
+      throw err
+    }
+  })

--- a/src/server/jwks.ts
+++ b/src/server/jwks.ts
@@ -1,0 +1,23 @@
+// Server-only lazy singleton JWKS resolver.
+// Fetches the public key set from rumors-api's /.well-known/jwks.json endpoint
+// and caches it via jose's built-in remote JWKSet cache (handles refresh,
+// cooldown, and timeouts internally). Consumed by jose.jwtVerify in jwt.ts.
+
+import { createRemoteJWKSet } from 'jose'
+import { getApiBase } from './api-base'
+
+let cachedJWKS: ReturnType<typeof createRemoteJWKSet> | null = null
+
+export function getJWKS(): ReturnType<typeof createRemoteJWKSet> {
+  if (!cachedJWKS) {
+    cachedJWKS = createRemoteJWKSet(
+      new URL('/.well-known/jwks.json', getApiBase()),
+      {
+        cacheMaxAge: 10 * 60 * 1000,
+        cooldownDuration: 30 * 1000,
+        timeoutDuration: 5 * 1000,
+      },
+    )
+  }
+  return cachedJWKS
+}

--- a/src/server/jwt.ts
+++ b/src/server/jwt.ts
@@ -1,0 +1,33 @@
+// Verifies the BFF session cookie JWT against rumors-api's JWKS so we can read
+// the user id locally without a per-request `GetUser` round-trip. Pin algorithm
+// to RS256 to defend against alg-confusion (e.g. forged HS256 token using the
+// public key as a shared secret). Throws on invalid signature, expired token,
+// missing claims, or wrong alg — callers decide how to map to HTTP status.
+
+import { jwtVerify } from 'jose'
+import { getJWKS } from './jwks'
+
+export interface VerifiedSession {
+  userId: string
+  issuedAt: number
+  expiresAt: number
+}
+
+export async function verifySessionToken(
+  token: string,
+): Promise<VerifiedSession> {
+  const { payload } = await jwtVerify(token, getJWKS(), {
+    algorithms: ['RS256'],
+  })
+  if (typeof payload.sub !== 'string') {
+    throw new Error('JWT missing sub claim')
+  }
+  if (typeof payload.iat !== 'number' || typeof payload.exp !== 'number') {
+    throw new Error('JWT missing iat/exp claims')
+  }
+  return {
+    userId: payload.sub,
+    issuedAt: payload.iat,
+    expiresAt: payload.exp,
+  }
+}

--- a/src/server/me.functions.ts
+++ b/src/server/me.functions.ts
@@ -1,14 +1,19 @@
 // TanStack Start server function exposing the current logged-in user to the
 // client. Reads the HttpOnly cofacts_session cookie via h3's getCookie and
-// dispatches the GetUser GraphQL query through cofactsExec. Always resolves —
-// never throws — so loaders and effects can call it without try/catch
-// boilerplate; cofactsExec throws are caught here and mapped to null.
+// dispatches the GetUser GraphQL query through cofactsExec. If GetUser fails
+// (upstream down, transient error) but a valid session cookie exists, falls
+// back to a minimal user derived from the JWT sub claim so the app keeps
+// showing the authenticated shell; the full profile will load on next SSR.
+// Returns null only when there is definitely no valid session at all.
 
 import { createServerFn } from '@tanstack/react-start'
+import { getCookie } from '@tanstack/react-start/server'
 
 import { cofactsExec } from '@/lib/cofactsExec'
 import { graphql } from './gql'
 import type { GetCurrentUserQuery } from './gql/graphql'
+import { verifySessionToken } from './jwt'
+import { SESSION_COOKIE_NAME } from './sessionCookie'
 
 export type CofactsUser = NonNullable<GetCurrentUserQuery['GetUser']>
 
@@ -30,6 +35,21 @@ export const getCurrentUserServerFn = createServerFn({ method: 'GET' }).handler(
       const data = await cofactsExec(GetCurrentUserDocument)
       return data.GetUser ?? null
     } catch {
+      const token = getCookie(SESSION_COOKIE_NAME)
+      if (token) {
+        try {
+          const { userId } = await verifySessionToken(token)
+          return {
+            id: userId,
+            name: null,
+            avatarUrl: null,
+            avatarType: null,
+            avatarData: null,
+          }
+        } catch {
+          // JWT also invalid — truly logged out
+        }
+      }
       return null
     }
   },

--- a/src/server/me.functions.ts
+++ b/src/server/me.functions.ts
@@ -1,10 +1,13 @@
 // TanStack Start server function exposing the current logged-in user to the
 // client. Reads the HttpOnly cofacts_session cookie via h3's getCookie and
-// dispatches the GetUser GraphQL query through cofactsExec. If GetUser fails
-// (upstream down, transient error) but a valid session cookie exists, falls
-// back to a minimal user derived from the JWT sub claim so the app keeps
-// showing the authenticated shell; the full profile will load on next SSR.
-// Returns null only when there is definitely no valid session at all.
+// dispatches the GetUser GraphQL query through cofactsExec.
+//
+// When GetUser throws but the session cookie is a valid JWT, returns a
+// minimal user populated from the JWT sub so AuthProvider's `['me']` query
+// (initialData + staleTime: Infinity) stays truthy and _app.tsx's `!user`
+// gate keeps rendering the authenticated shell. name/avatar remain null
+// until cache invalidation or a subsequent successful fetch. Returns null
+// only when no valid session cookie exists.
 
 import { createServerFn } from '@tanstack/react-start'
 import { getCookie } from '@tanstack/react-start/server'


### PR DESCRIPTION
Implements cofacts/ai#47.

## Summary

Thread the authenticated Cofacts user id end-to-end through chat, ADK, and Langfuse so per-user state (sessions, feedback, side panels) stays isolated. Authenticated ADK identity is resolved by verifying the BFF session JWT locally against rumors-api JWKS, avoiding per-request `GetUser` calls while preserving re-login behavior when the cookie expires. Replace per-region "logged-out" gating with a single layout-level landing.

## What changed

### Per-user identity end-to-end
- `src/server/adkUser.ts`, `src/server/jwt.ts`, `src/server/jwks.ts` — resolve the current ADK `user_id` from the HttpOnly `cofacts_session` JWT. The token is verified locally with `jose.jwtVerify` against `COFACTS_API_URL/.well-known/jwks.json`, pins `RS256`, and uses the `sub` claim as the Cofacts user id.
- Auth failures use the shared `AUTH_EXPIRED` sentinel so TanStack server function callers can trigger the global re-login flow after serialization.
- `src/lib/chatSessions.functions.ts`, `src/routes/api/run-sse.ts` — drop the hard-coded `ADK_USER_ID`; resolve per-request.

### Auth expiry and re-login handling
- `src/lib/authExpired.ts`, `src/router.tsx`, `src/lib/auth.tsx` — centralize client-side 401/auth-expired handling. Query/mutation errors clear user-scoped caches and open `LoginModal` with the current pathname as the post-login redirect target.
- `src/lib/chatCache.ts`, `src/routes/api/run-sse.ts` — SSE requests also participate in the same auth-expired flow instead of only showing a generic stream error.

### Feedback persistence
- `src/server/feedbackScores.functions.ts` — new server functions read and write the current user's per-trace feedback score through the Langfuse REST API, filtered server-side by `trace.userId`.
- `FeedbackButtons` seeds local state from `getFeedbackForTrace` so thumbs-up/down survives reloads and tab switches.
- Feedback writes now go through `submitFeedbackForTrace`, re-resolving auth on every submission so expired cookies produce the same re-login flow as other authenticated writes.
- Cache key includes `userId`; `clearUserScopedCache` evicts `['feedback']` on logout.

### Logout cache hygiene
- `src/lib/auth.tsx` — `logout()` now removes user-scoped React Query caches (`['sessions']`, `['chat']`, `['feedback']`), not just `['me']`. These caches can use long lifetimes, so `removeQueries` is needed to prevent the previous user's data leaking to an anonymous viewer in the same tab.

### Logged-out landing (single switch)
- `src/routes/_app.tsx` — when `useAuth().user` is null, render only `<Header />` + `<LoggedOutLanding />` and skip the sidebar + `<Outlet />` entirely.
- New `LoggedOutLanding`, `WelcomeHero`, refined `LoginPrompt` (now requires explicit `message` prop).
- Removes scattered `user ?` branches in `ChatArea` and the landing route, and prevents authenticated-only fetches (sessions, chat history, feedback scores) from firing while logged out.

## Screenshots

Logged-out landing — desktop:

![Logged-out landing (desktop)](https://raw.githubusercontent.com/cofacts/ai/pr-51-assets/01-logged-out-desktop.png)

Logged-out landing — mobile:

![Logged-out landing (mobile)](https://raw.githubusercontent.com/cofacts/ai/pr-51-assets/02-logged-out-mobile.png)

## Known issue

- If a browser tab is left on `/session/:sessionId` and the user switches to another Cofacts account, the URL may point to a session owned by the previous ADK user. ADK correctly returns `404 Session not found`, but the UI currently surfaces it as a generic ADK communication error instead of redirecting home or explaining that the session does not belong to the current account. This is intentionally left for a follow-up.

## Notes

- No new env vars beyond the optional `LANGFUSE_*` server-side keys already documented in `.env.example` (used to enable feedback persistence; absent → feature degrades gracefully to "no persisted score").
- Cross-tab logout sync (tab A logs out → tab B still shows logged-in UI until next API call returns 401) is intentionally out of scope; matches current cofacts.tw behaviour.
