### PR TITLE
fix(FeedbackButtons): wrap each button in its own PopoverTrigger [Trivial]

### DIFF
--- a/src/components/FeedbackButtons.tsx
+++ b/src/components/FeedbackButtons.tsx
@@ -19,8 +19,6 @@ export function FeedbackButtons({ traceId }: FeedbackButtonsProps) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
 
   const handleFeedback = (e: React.MouseEvent, value: 1 | -1) => {
-    // Stop event from propagating to the trigger so the trigger doesn't automatically open it when resetting
-    e.stopPropagation()
     const next = feedbackGiven === value ? null : value
     setFeedbackGiven(next)
 
@@ -74,8 +72,8 @@ export function FeedbackButtons({ traceId }: FeedbackButtonsProps) {
           if (!open) setIsPopoverOpen(false)
         }}
       >
-        <PopoverTrigger render={<div className="flex gap-3" />}>
-          <button
+        <div className="flex gap-3">
+          <PopoverTrigger
             onClick={(e) => handleFeedback(e, 1)}
             className={`p-1 rounded hover:bg-gray-100 transition-colors ${
               feedbackGiven === 1
@@ -86,8 +84,8 @@ export function FeedbackButtons({ traceId }: FeedbackButtonsProps) {
             <span className="material-symbols-outlined text-[18px]">
               thumb_up
             </span>
-          </button>
-          <button
+          </PopoverTrigger>
+          <PopoverTrigger
             onClick={(e) => handleFeedback(e, -1)}
             className={`p-1 rounded hover:bg-gray-100 transition-colors ${
               feedbackGiven === -1
@@ -98,8 +96,8 @@ export function FeedbackButtons({ traceId }: FeedbackButtonsProps) {
             <span className="material-symbols-outlined text-[18px]">
               thumb_down
             </span>
-          </button>
-        </PopoverTrigger>
+          </PopoverTrigger>
+        </div>
         <PopoverContent align="start">
           <FeedbackPopoverContent
             isPositive={feedbackGiven === 1}


### PR DESCRIPTION
## Summary

- Replaces a single `PopoverTrigger` wrapping a `<div>` with individual `PopoverTrigger` per button
- Fixes a Base UI console warning: trigger expected a native `<button>` but received a `<div>` via the `render` prop
- Removes now-unnecessary `e.stopPropagation()` call

## Test plan

- [x] Thumb up / thumb down buttons still open the feedback popover
- [x] Re-clicking the same button closes the popover and clears the selection
- [x] No Base UI warning in browser console

### Before
(Only exists on localhost)
<img width="1553" height="915" alt="圖片" src="https://github.com/user-attachments/assets/2bc034e3-07b1-4bd6-a668-33af945ec3f8" />

### After

https://github.com/user-attachments/assets/64b1d396-67ac-462a-a2cb-7049f9c81efc



🤖 Generated with [Claude Code](https://claude.com/claude-code)