### PR TITLE
fix(instrumentation): propagate correct session.id to Langfuse via langfuse.session.id

### DIFF
--- a/adk/cofacts_ai/instrumentation.py
+++ b/adk/cofacts_ai/instrumentation.py
@@ -49,9 +49,6 @@ class RootSessionSpanProcessor(SpanProcessor):
         if isinstance(session, str):
             span.set_attribute(_LANGFUSE_SESSION_ID_ATTR, session)
 
-    def on_end(self, span):
-        pass
-
 
 def setup_instrumentation():
     """

--- a/adk/cofacts_ai/instrumentation.py
+++ b/adk/cofacts_ai/instrumentation.py
@@ -10,7 +10,6 @@ from openinference.semconv.trace import SpanAttributes
 from opentelemetry import trace as otel_trace
 from opentelemetry.sdk.trace import SpanProcessor
 from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
-from opentelemetry.trace import get_current_span
 
 logger = logging.getLogger(__name__)
 
@@ -42,10 +41,13 @@ class RootSessionSpanProcessor(SpanProcessor):
             return
         trace_id = span_ctx.trace_id
 
-        parent_span_ctx = get_current_span(parent_context).get_span_context()
-        if not parent_span_ctx.is_valid:
-            # Root or context-detached sub-agent span: register the first one seen.
-            # setdefault is atomic under the GIL and returns the winning value.
+        # span.parent is the authoritative OTel parent SpanContext (set during
+        # span creation). parent_context is the ambient context at call time and
+        # may not reflect the actual parent when openinference detaches context.
+        is_root = span.parent is None or not span.parent.is_valid
+        if is_root:
+            # Root or context-detached span: register the first session seen per
+            # trace. setdefault is atomic under the GIL.
             root = self._root_sessions.setdefault(trace_id, session_id)
             if root != session_id:
                 span.set_attribute(_SESSION_ID_ATTR, root)
@@ -105,4 +107,6 @@ class LangfuseTracingPlugin(BasePlugin):
             # future events in this invocation before they are saved to the DB.
             if invocation_context.run_config.custom_metadata is None:
                 invocation_context.run_config.custom_metadata = {}
-            invocation_context.run_config.custom_metadata[_LANGFUSE_TRACE_ID_KEY] = trace_id
+            invocation_context.run_config.custom_metadata[_LANGFUSE_TRACE_ID_KEY] = (
+                trace_id
+            )

--- a/adk/cofacts_ai/instrumentation.py
+++ b/adk/cofacts_ai/instrumentation.py
@@ -30,6 +30,7 @@ class RootSessionSpanProcessor(SpanProcessor):
 
     def __init__(self):
         self._root_sessions: dict[int, str] = {}
+        self._root_spans: dict[int, int] = {}  # trace_id -> span_id that registered the session
 
     def on_start(self, span, parent_context=None):
         session_id = (span.attributes or {}).get(_SESSION_ID_ATTR)
@@ -49,7 +50,11 @@ class RootSessionSpanProcessor(SpanProcessor):
             # Root or context-detached span: register the first session seen per
             # trace. setdefault is atomic under the GIL.
             root = self._root_sessions.setdefault(trace_id, session_id)
-            if root != session_id:
+            if root == session_id:
+                # We just registered this trace — record this span as the
+                # canonical root so on_end knows when it's safe to clean up.
+                self._root_spans[trace_id] = span_ctx.span_id
+            else:
                 span.set_attribute(_SESSION_ID_ATTR, root)
             return
 
@@ -58,8 +63,15 @@ class RootSessionSpanProcessor(SpanProcessor):
             span.set_attribute(_SESSION_ID_ATTR, root)
 
     def on_end(self, span):
-        if span.parent is None and span.context is not None:
-            self._root_sessions.pop(span.context.trace_id, None)
+        if span.context is None:
+            return
+        trace_id = span.context.trace_id
+        # Only clean up when the specific span that registered the root session ends.
+        # Sub-agent invocation spans are also context-detached (span.parent is None)
+        # but must not trigger cleanup before their child agent_run spans are processed.
+        if self._root_spans.get(trace_id) == span.context.span_id:
+            self._root_sessions.pop(trace_id, None)
+            self._root_spans.pop(trace_id, None)
 
 
 def setup_instrumentation():

--- a/adk/cofacts_ai/instrumentation.py
+++ b/adk/cofacts_ai/instrumentation.py
@@ -14,8 +14,11 @@ from opentelemetry.trace import get_current_span
 
 logger = logging.getLogger(__name__)
 
+# openinference semconv: "session.id"
 _SESSION_ID_ATTR = SpanAttributes.SESSION_ID
+# Langfuse-specific attribute that takes precedence over session.id in OTLP ingestion
 _LANGFUSE_SESSION_ID_ATTR = "langfuse.session.id"
+# Key used in event.custom_metadata to link events back to their Langfuse trace
 _LANGFUSE_TRACE_ID_KEY = "langfuse_trace_id"
 
 

--- a/adk/cofacts_ai/instrumentation.py
+++ b/adk/cofacts_ai/instrumentation.py
@@ -15,6 +15,7 @@ from opentelemetry.trace import get_current_span
 logger = logging.getLogger(__name__)
 
 _SESSION_ID_ATTR = SpanAttributes.SESSION_ID
+_LANGFUSE_TRACE_ID_KEY = "langfuse_trace_id"
 
 
 class RootSessionSpanProcessor(SpanProcessor):
@@ -29,7 +30,7 @@ class RootSessionSpanProcessor(SpanProcessor):
     """
 
     def __init__(self):
-        self._root_sessions: dict[int, str] = {}  # trace_id -> root session_id
+        self._root_sessions: dict[int, str] = {}
 
     def on_start(self, span, parent_context=None):
         session_id = (span.attributes or {}).get(_SESSION_ID_ATTR)
@@ -42,14 +43,17 @@ class RootSessionSpanProcessor(SpanProcessor):
         trace_id = span_ctx.trace_id
 
         parent_span_ctx = get_current_span(parent_context).get_span_context()
-        is_root = not parent_span_ctx.is_valid
-
-        if is_root and trace_id not in self._root_sessions:
-            self._root_sessions[trace_id] = session_id
-        else:
-            root = self._root_sessions.get(trace_id)
-            if root and session_id != root:
+        if not parent_span_ctx.is_valid:
+            # Root or context-detached sub-agent span: register the first one seen.
+            # setdefault is atomic under the GIL and returns the winning value.
+            root = self._root_sessions.setdefault(trace_id, session_id)
+            if root != session_id:
                 span.set_attribute(_SESSION_ID_ATTR, root)
+            return
+
+        root = self._root_sessions.get(trace_id)
+        if root and session_id != root:
+            span.set_attribute(_SESSION_ID_ATTR, root)
 
     def on_end(self, span):
         if span.parent is None and span.context is not None:
@@ -101,7 +105,4 @@ class LangfuseTracingPlugin(BasePlugin):
             # future events in this invocation before they are saved to the DB.
             if invocation_context.run_config.custom_metadata is None:
                 invocation_context.run_config.custom_metadata = {}
-            invocation_context.run_config.custom_metadata["langfuse_trace_id"] = (
-                trace_id
-            )
-        return None
+            invocation_context.run_config.custom_metadata[_LANGFUSE_TRACE_ID_KEY] = trace_id

--- a/adk/cofacts_ai/instrumentation.py
+++ b/adk/cofacts_ai/instrumentation.py
@@ -1,12 +1,60 @@
-import os
 import logging
-from openinference.instrumentation.google_adk import GoogleADKInstrumentor
-from langfuse import get_client
-from google.adk.plugins.base_plugin import BasePlugin
+import os
+from typing import cast
+
 from google.adk.agents.invocation_context import InvocationContext
-from google.adk.events.event import Event
+from google.adk.plugins.base_plugin import BasePlugin
+from langfuse import get_client
+from openinference.instrumentation.google_adk import GoogleADKInstrumentor
+from openinference.semconv.trace import SpanAttributes
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace import SpanProcessor
+from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
+from opentelemetry.trace import get_current_span
 
 logger = logging.getLogger(__name__)
+
+_SESSION_ID_ATTR = SpanAttributes.SESSION_ID
+
+
+class RootSessionSpanProcessor(SpanProcessor):
+    """
+    Ensures all spans in an OTel trace share the root span's session.id.
+
+    Google ADK spawns a new session per sub-agent invocation, causing
+    openinference to stamp sub-agent spans with a different session.id.
+    Langfuse's last-write-wins OTLP ingestion then assigns the trace to the
+    wrong session. This processor overwrites every child span's session.id
+    with the root span's value before the span is exported.
+    """
+
+    def __init__(self):
+        self._root_sessions: dict[int, str] = {}  # trace_id -> root session_id
+
+    def on_start(self, span, parent_context=None):
+        session_id = (span.attributes or {}).get(_SESSION_ID_ATTR)
+        if not isinstance(session_id, str):
+            return
+
+        span_ctx = span.get_span_context()
+        if span_ctx is None:
+            return
+        trace_id = span_ctx.trace_id
+
+        parent_span_ctx = get_current_span(parent_context).get_span_context()
+        is_root = not parent_span_ctx.is_valid
+
+        if is_root and trace_id not in self._root_sessions:
+            self._root_sessions[trace_id] = session_id
+        else:
+            root = self._root_sessions.get(trace_id)
+            if root and session_id != root:
+                span.set_attribute(_SESSION_ID_ATTR, root)
+
+    def on_end(self, span):
+        if span.parent is None and span.context is not None:
+            self._root_sessions.pop(span.context.trace_id, None)
+
 
 def setup_instrumentation():
     """
@@ -20,6 +68,9 @@ def setup_instrumentation():
 
     if langfuse.auth_check():
         GoogleADKInstrumentor().instrument()
+        cast(SDKTracerProvider, otel_trace.get_tracer_provider()).add_span_processor(
+            RootSessionSpanProcessor()
+        )
         logger.info("Langfuse instrumentation initialized.")
     else:
         logger.warning("Langfuse authentication failed. Skipping instrumentation.")
@@ -42,15 +93,15 @@ class LangfuseTracingPlugin(BasePlugin):
     def __init__(self):
         super().__init__(name="langfuse_tracing")
 
-    async def before_run_callback(
-        self, *, invocation_context: InvocationContext
-    ):
+    async def before_run_callback(self, *, invocation_context: InvocationContext):
         langfuse = get_client()
         trace_id = langfuse.get_current_trace_id()
-        if trace_id:
+        if trace_id and invocation_context.run_config is not None:
             # Set the trace ID in run_config so ADK automatically stamps all
             # future events in this invocation before they are saved to the DB.
             if invocation_context.run_config.custom_metadata is None:
                 invocation_context.run_config.custom_metadata = {}
-            invocation_context.run_config.custom_metadata["langfuse_trace_id"] = trace_id
+            invocation_context.run_config.custom_metadata["langfuse_trace_id"] = (
+                trace_id
+            )
         return None

--- a/adk/cofacts_ai/instrumentation.py
+++ b/adk/cofacts_ai/instrumentation.py
@@ -10,68 +10,47 @@ from openinference.semconv.trace import SpanAttributes
 from opentelemetry import trace as otel_trace
 from opentelemetry.sdk.trace import SpanProcessor
 from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
+from opentelemetry.trace import get_current_span
 
 logger = logging.getLogger(__name__)
 
 _SESSION_ID_ATTR = SpanAttributes.SESSION_ID
+_LANGFUSE_SESSION_ID_ATTR = "langfuse.session.id"
 _LANGFUSE_TRACE_ID_KEY = "langfuse_trace_id"
 
 
 class RootSessionSpanProcessor(SpanProcessor):
     """
-    Ensures all spans in an OTel trace share the root span's session.id.
+    Stamps langfuse.session.id on every span by propagating from the parent.
 
-    Google ADK spawns a new session per sub-agent invocation, causing
-    openinference to stamp sub-agent spans with a different session.id.
-    Langfuse's last-write-wins OTLP ingestion then assigns the trace to the
-    wrong session. This processor overwrites every child span's session.id
-    with the root span's value before the span is exported.
+    GoogleADKInstrumentor incorrectly stamps sub-agent spans with ADK-internal
+    session UUIDs (https://github.com/Arize-ai/openinference/issues/3117).
+    Langfuse gives langfuse.session.id precedence over session.id, so we read
+    the parent span's session at on_start time and copy it down — non-destructively
+    and without maintaining any state.
     """
 
-    def __init__(self):
-        self._root_sessions: dict[int, str] = {}
-        self._root_spans: dict[int, int] = {}  # trace_id -> span_id that registered the session
-
     def on_start(self, span, parent_context=None):
-        session_id = (span.attributes or {}).get(_SESSION_ID_ATTR)
-        if not isinstance(session_id, str):
-            return
+        parent = get_current_span(parent_context)
+        parent_attrs = getattr(parent, "attributes", None) or {}
 
-        span_ctx = span.get_span_context()
-        if span_ctx is None:
-            return
-        trace_id = span_ctx.trace_id
+        # Prefer langfuse.session.id (already corrected) over session.id (may be wrong)
+        session = (
+            parent_attrs.get(_LANGFUSE_SESSION_ID_ATTR)
+            or parent_attrs.get(_SESSION_ID_ATTR)
+        )
 
-        # span.parent is the authoritative OTel parent SpanContext (set during
-        # span creation). parent_context is the ambient context at call time and
-        # may not reflect the actual parent when openinference detaches context.
-        is_root = span.parent is None or not span.parent.is_valid
-        if is_root:
-            # Root or context-detached span: register the first session seen per
-            # trace. setdefault is atomic under the GIL.
-            root = self._root_sessions.setdefault(trace_id, session_id)
-            if root == session_id:
-                # We just registered this trace — record this span as the
-                # canonical root so on_end knows when it's safe to clean up.
-                self._root_spans[trace_id] = span_ctx.span_id
-            else:
-                span.set_attribute(_SESSION_ID_ATTR, root)
-            return
+        if session is None:
+            # No parent session — fall back to own session.id (root span)
+            own = (span.attributes or {}).get(_SESSION_ID_ATTR)
+            if isinstance(own, str):
+                session = own
 
-        root = self._root_sessions.get(trace_id)
-        if root and session_id != root:
-            span.set_attribute(_SESSION_ID_ATTR, root)
+        if isinstance(session, str):
+            span.set_attribute(_LANGFUSE_SESSION_ID_ATTR, session)
 
     def on_end(self, span):
-        if span.context is None:
-            return
-        trace_id = span.context.trace_id
-        # Only clean up when the specific span that registered the root session ends.
-        # Sub-agent invocation spans are also context-detached (span.parent is None)
-        # but must not trigger cleanup before their child agent_run spans are processed.
-        if self._root_spans.get(trace_id) == span.context.span_id:
-            self._root_sessions.pop(trace_id, None)
-            self._root_spans.pop(trace_id, None)
+        pass
 
 
 def setup_instrumentation():


### PR DESCRIPTION
## Problem

The current Langfuse integration would generate multiple Langfuse sessions for 1 chatroom.

Ex: 
- the main session https://langfuse.cofacts.tw/project/cmm0emerr0001qi07eugd0760/sessions/6498b3f2-860c-494f-a955-5461688c06d6
- a trace with correct session_id but somehow created wrong Langfuse session https://langfuse.cofacts.tw/project/cmm0emerr0001qi07eugd0760/sessions/5eaedb9e-12b9-4664-93e6-41352bedf39d

## Summary

- Adds `RootSessionSpanProcessor` to ensure all spans in a trace land in the correct Langfuse session
- `openinference-instrumentation-google-adk` incorrectly stamps sub-agent spans with ADK-internal session UUIDs instead of the user-facing `session_id` (upstream bug: https://github.com/Arize-ai/openinference/issues/3117)
- Fixes this by reading the parent span's session at `on_start` time and writing it as `langfuse.session.id`, which Langfuse gives precedence over `session.id` in OTLP ingestion
- Stateless implementation — no dicts, no cleanup logic, no edge cases

## Test plan

Subagent spans are now assigned with parent session ID
<img width="1865" height="864" alt="圖片" src="https://github.com/user-attachments/assets/88b531ce-c44a-48db-aa6c-5388f37e3e75" />


- [x] Trigger an invocation that calls a sub-agent (investigator or verifier)
- [x] Confirm the Langfuse trace `sessionId` matches the user-facing ADK session shown in the chat URL
- [x] Confirm all observations (including `call_llm` spans under sub-agents) carry `langfuse.session.id` equal to the root session

🤖 Generated with [Claude Code](https://claude.com/claude-code)