### PR TITLE
fix: prevent AI from echoing draft content after draft_factcheck_response

### DIFF
--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -607,10 +607,6 @@ ai_writer = LlmAgent(
        - Use only claims confirmed by verifier in step 5.
        - Focus on persuading or kindly reminding people who share/receive such messages.
 
-    8. **Multi-Perspective Review**: Get comprehensive feedback from all political perspectives on the final reply
-
-    9. **Finalize**: Incorporate feedback and finalize the reply
-
     **Flexible Support:**
     - Offer sub-agent capabilities as needed, not as a rigid sequence
     - Listen to what the user wants to focus on

--- a/adk/cofacts_ai/tools.py
+++ b/adk/cofacts_ai/tools.py
@@ -473,7 +473,7 @@ def draft_factcheck_response(
             ),
         }
 
-    return {"success": True, "text": "草稿已儲存，請人工編輯者審閱後送出。"}
+    return {"success": True, "text": "Draft saved. Click the tool call result above to review it, then submit to Cofacts when ready."}
 
 
 async def resolve_vertex_redirect(url: str) -> str:


### PR DESCRIPTION
## Summary

- Removes steps 8 and 9 ("Multi-Perspective Review" and "Finalize") from the AI writer workflow so that `draft_factcheck_response` is the final step — eliminating the AI's motivation to echo draft content in text afterward
- Updates the tool's success message from Chinese (`草稿已儲存，請人工編輯者審閱後送出。`) to English, and clarifies that the same user chatting will review and submit the draft (no hand-off to a separate editor implied)

## Root cause

Steps 8 and 9 came after calling the tool, giving the AI a structural reason to repeat the full draft in plain text (so the political-perspective agents could review it). This caused consistent hallucinations like "您可以直接前往 Cofacts 後台進行最終確認" across 14 observations in Langfuse.

## Test plan

- [ ] Start a new ADK session, provide a Cofacts article URL
- [ ] Let the AI run the full workflow until `draft_factcheck_response` is called
- [ ] Confirm the AI does NOT repeat the draft content, mention "後台"/"系統"/"cofacts.tw", or imply the draft was published
- [ ] Confirm the tool result shows the new English success message

https://claude.ai/code/session_014g8CdKUsSq6uWyKj4e49x3

---
_Generated by [Claude Code](https://claude.ai/code/session_014g8CdKUsSq6uWyKj4e49x3)_