### PR TITLE
fix(feedback): use v1 /api/public/scores for thumbs-up POST

### DIFF
--- a/src/server/__tests__/feedbackScores.test.ts
+++ b/src/server/__tests__/feedbackScores.test.ts
@@ -184,7 +184,7 @@ describe('postFeedbackForTrace', () => {
 
     expect(fetchSpy).toHaveBeenCalledTimes(1)
     const [calledUrl, init] = fetchSpy.mock.calls[0] as [URL, RequestInit]
-    expect(calledUrl.pathname).toBe('/api/public/v2/scores')
+    expect(calledUrl.pathname).toBe('/api/public/scores')
     expect(init.method).toBe('POST')
     const headers = init.headers as Record<string, string>
     expect(headers.Authorization).toBe(

--- a/src/server/feedbackScores.functions.ts
+++ b/src/server/feedbackScores.functions.ts
@@ -101,7 +101,7 @@ export async function postFeedbackForTrace(
   const secretKey = process.env.LANGFUSE_SECRET_KEY
   if (!baseUrl || !publicKey || !secretKey) return
 
-  const url = new URL('/api/public/v2/scores', baseUrl)
+  const url = new URL('/api/public/scores', baseUrl)
   const auth = Buffer.from(`${publicKey}:${secretKey}`).toString('base64')
   // Deterministic id makes repeated submissions for the same trace upsert
   // (Langfuse merges scores by id within the project), so toggling thumbs


### PR DESCRIPTION
## Summary

Fix thumbs-up/down feedback submission, broken on `master` since #51.

`postFeedbackForTrace` POSTs to `/api/public/v2/scores`, but that endpoint is **read-only** in Langfuse — only `GET` is defined; no `POST` handler exists ([langfuse/web/src/pages/api/public/v2/scores/index.ts](https://github.com/langfuse/langfuse/blob/main/web/src/pages/api/public/v2/scores/index.ts)). All score writes must go through v1.

Minimal change: POST URL → `/api/public/scores` (v1). The GET path (`fetchFeedbackForTrace`) stays on v2 intentionally — it relies on the v2-only `fields=scores,trace` query parameter for `userId` filtering, and v2 GET is Langfuse's recommended read API. So the resulting **GET v2 + POST v1** split matches Langfuse's official guidance.

## Background: API vs SDK

Before #51, this code used the `LangfuseWeb` browser SDK on the client. #51 (commit c2fe726) moved score writes to the server — good, because it enforces auth + integrates with the React Query MutationCache → LoginModal flow — but instead of using the Langfuse server SDK, it called the HTTP API directly with `fetch`. That's where the wrong endpoint snuck in.

### Why direct `fetch` is fine here

- **Synchronous request/response semantics**: a user-triggered single write needs immediate success/failure to bubble up to React Query. The Langfuse SDK is designed for fire-and-forget batched ingestion: `langfuse.score()` enqueues, you need `flushAsync()` to send, and errors come through an `EventEmitter` — awkward shape for one-shot writes.
- **Minimal complexity**: ~10 lines of `fetch` + `Authorization` vs. the SDK's per-call instantiate + subscribe/unsubscribe pattern (see `langfuse-server-sdk-feedback` branch, commit e09cf38).
- **One less black box** to reason about for a single-shot write.

### Trade-offs of direct API

- We hand-code endpoint paths — this PR is literally about that going wrong.
- No automatic schema/typing from upstream; we maintain the request shape ourselves.
- If Langfuse changes the wire format we won't get it for free.

### Future option

If we later need to emit traces/events from the server (high volume, batched), or if direct-API ergonomics keep biting us, switching to the `Langfuse` server SDK is straightforward — `langfuse-server-sdk-feedback` (commit e09cf38) is a working sketch.

## Verification

- `pnpm test feedbackScores` → 71/71 ✓
- Endpoint check against Langfuse source: v2 `index.ts` exports only `GET`; v1 exports `POST` + `GET` + `DELETE`.
