### PR TITLE
Add Langfuse env to ingress container

### DIFF
--- a/service.template.yaml
+++ b/service.template.yaml
@@ -30,7 +30,12 @@ spec:
           value: "http://localhost:8000"
         - name: COFACTS_API_URL
           value: "${COFACTS_API_URL}"
-        # Add other frontend environment variables here
+        - name: LANGFUSE_PUBLIC_KEY
+          value: "${LANGFUSE_PUBLIC_KEY}"
+        - name: LANGFUSE_SECRET_KEY
+          value: "${LANGFUSE_SECRET_KEY}"
+        - name: LANGFUSE_BASE_URL
+          value: "https://langfuse.cofacts.tw"
       - name: backend
         image: ${BACKEND_IMAGE}
         resources:


### PR DESCRIPTION
## What changed

- Add `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL` to the Cloud Run `ingress` container.
- Keep the existing backend Langfuse configuration unchanged.

## Why

Cofacts AI feedback is submitted through a React Start server function that runs in the `ingress` container. The backend container already had Langfuse env vars, which made ADK tracing work, but the ingress container did not. As a result, feedback requests returned success while `postFeedbackForTrace()` no-oped because Langfuse env vars were missing.

## Impact

After deployment, `dev.cofacts.ai` / Cloud Run ingress server functions can actually send thumbs-up/down scores to Langfuse.

## Validation

- Rendered `service.template.yaml` locally with placeholder env values.
- Parsed the rendered YAML and confirmed `ingress` includes the Langfuse env vars.
- Also hot-fixed Cloud Run service `cofacts-ai` to revision `cofacts-ai-00202-g9b` and confirmed `dev.cofacts.ai` returns 200.
