### PR TITLE
Fix Langfuse score read fields

### DIFF
--- a/src/server/__tests__/feedbackScores.test.ts
+++ b/src/server/__tests__/feedbackScores.test.ts
@@ -59,7 +59,7 @@ describe('fetchFeedbackForTrace', () => {
     expect(calledUrl.searchParams.get('traceId')).toBe('trace-abc')
     expect(calledUrl.searchParams.get('name')).toBe('user-thumbs')
     expect(calledUrl.searchParams.get('userId')).toBe('user-42')
-    expect(calledUrl.searchParams.get('fields')).toBe('scores,trace')
+    expect(calledUrl.searchParams.get('fields')).toBe('score,trace')
     expect(calledUrl.searchParams.get('filter')).toBeNull()
     const auth = (init.headers as Record<string, string>).Authorization
     expect(auth).toBe(

--- a/src/server/feedbackScores.functions.ts
+++ b/src/server/feedbackScores.functions.ts
@@ -60,7 +60,7 @@ export async function fetchFeedbackForTrace(
   // userId filters server-side by trace.userId; requires 'trace' in fields
   // per Langfuse v2 API contract.
   url.searchParams.set('userId', userId)
-  url.searchParams.set('fields', 'scores,trace')
+  url.searchParams.set('fields', 'score,trace')
   url.searchParams.set('limit', '50')
 
   const auth = Buffer.from(`${publicKey}:${secretKey}`).toString('base64')


### PR DESCRIPTION
## What changed

- Change the Langfuse score read query from `fields=scores,trace` to `fields=score,trace`.
- Update the feedback score unit test to match the actual Langfuse v2 API parameter.

## Why

Feedback submission now works, but reloading the page did not restore the previous thumbs-up/down state. The read side was calling `/api/public/v2/scores` with `fields=scores,trace`, which Langfuse rejects with `400 Bad Request` and the message `Scores needs to be selected always.` The accepted field group is singular: `score`.

## Validation

- `pnpm vitest run src/server/__tests__/feedbackScores.test.ts` passes 12 tests.
- Queried the real Langfuse API for the PR preview trace with `fields=score,trace`; it returned `200` and the expected `user-thumbs` score.
