### PR TITLE
feat(verifier): inject YouTube URLs as FileData for native video understanding

### DIFF
--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -322,6 +322,21 @@ ai_verifier = LlmAgent(
     - A source supports a claim only if its content contains direct, specific evidence — not merely related topic
     - Quote the supporting passage verbatim
     - Do not add analysis or verdicts beyond what the sources say
+
+    ## Hard Rules — No Exceptions
+
+    **No training knowledge**: For video or media content, report ONLY what is directly visible or
+    audible. Never use background knowledge to identify the event name, date, location, organizer,
+    or a person's full identity. If the video does not explicitly state it, write
+    "影片未說明 / cannot be determined from this video."
+
+    **Video title and hashtags are not evidence**: The title, description, and hashtags of a YouTube
+    video are added by the uploader and may be inaccurate or intentionally misleading.
+    Do NOT treat them as evidence about the event depicted in the video.
+
+    **No invented citations**: The Sources list MUST ONLY contain URLs that were provided as input.
+    Never cite a news article, report, or webpage that was not in the original URL list —
+    even if you believe such articles exist.
     """,
     tools=[url_context],
 )

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -564,6 +564,26 @@ async def after_tool(
         return None
 
 
+def handle_writer_tool_error(
+    tool: BaseTool,
+    args: dict,
+    tool_context: Any,
+    error: Exception,
+) -> Optional[dict]:
+    """on_tool_error_callback for ai_writer.
+
+    Catches any exception thrown by a tool so the writer turn does not crash.
+    Returns a structured error dict the writer can read and react to.
+    """
+    return {
+        "error": type(error).__name__,
+        "message": (
+            f"[SYSTEM] Tool '{tool.name}' failed with {type(error).__name__}: {error}. "
+            "Please note this failure and continue with available information."
+        ),
+    }
+
+
 # Main AI Writer - Orchestrator agent
 #
 # Note: Due to ADK limitations, we cannot mix built-in tools (google_search, url_context)
@@ -585,6 +605,7 @@ ai_writer = LlmAgent(
         )
     ),
     after_tool_callback=after_tool,
+    on_tool_error_callback=handle_writer_tool_error,
     after_agent_callback=update_last_event_time,
     instruction=f"""
     You are an AI Writer and orchestrator for the Cofacts fact-checking system. Today is {datetime.now().strftime("%Y-%m-%d")}.

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -10,6 +10,7 @@ This module implements a hierarchical agent system with:
 
 import asyncio
 import json
+import logging
 import re
 import time
 from datetime import datetime
@@ -19,6 +20,7 @@ from dotenv import load_dotenv
 from google.adk.agents import LlmAgent
 from google.adk.agents.callback_context import CallbackContext
 from google.adk.apps import App
+from google.adk.models.llm_request import LlmRequest
 from google.adk.models.llm_response import LlmResponse
 from google.adk.tools import google_search, url_context
 from google.adk.tools.agent_tool import AgentTool
@@ -35,6 +37,8 @@ from .tools import (
 )
 
 load_dotenv()
+
+logger = logging.getLogger(__name__)
 
 # Initialize Langfuse instrumentation for observability
 setup_instrumentation()
@@ -214,7 +218,7 @@ _YOUTUBE_URL_RE = re.compile(
 
 
 def inject_youtube_filedata(
-    callback_context: CallbackContext, llm_request: Any
+    callback_context: CallbackContext, llm_request: LlmRequest
 ) -> None:
     """Before-model callback for ai_investigator and ai_verifier.
 
@@ -225,20 +229,23 @@ def inject_youtube_filedata(
 
     Ref: https://ai.google.dev/gemini-api/docs/video-understanding#youtube
     """
-    for content in llm_request.contents:
-        if content.role != "user" or not content.parts:
-            continue
-        youtube_urls = []
-        for part in content.parts:
-            if part.text:
-                youtube_urls.extend(_YOUTUBE_URL_RE.findall(part.text))
+    try:
         seen = set()
-        for url in youtube_urls:
-            if url not in seen:
-                seen.add(url)
-                content.parts.append(
-                    genai_types.Part(file_data=genai_types.FileData(file_uri=url))
-                )
+        for content in llm_request.contents:
+            if content.role != "user" or not content.parts:
+                continue
+            youtube_urls = []
+            for part in content.parts:
+                if part.text:
+                    youtube_urls.extend(_YOUTUBE_URL_RE.findall(part.text))
+            for url in youtube_urls:
+                if url not in seen:
+                    seen.add(url)
+                    content.parts.append(
+                        genai_types.Part(file_data=genai_types.FileData(file_uri=url))
+                    )
+    except Exception:
+        logger.exception("inject_youtube_filedata failed; skipping YouTube injection")
     return None
 
 
@@ -304,11 +311,11 @@ ai_verifier = LlmAgent(
     read all the URLs and determine which sources actually support each claim.
 
     ## Your Task
-    1. Call url_context for ALL provided URLs in one call (up to 20) — this is MANDATORY.
-       url_context fetches the web PAGE metadata (title, publish date, description), which is
-       always required regardless of what else is visible in this conversation.
-       Note: for video URLs (e.g. YouTube), page metadata and video frames are complementary —
-       url_context gives you the upload date; the video gives you observable content.
+    1. Call url_context for ALL provided URLs in one call (up to 20) — this is MANDATORY, even for video URLs.
+       url_context fetches web PAGE metadata (title, publish date, description) from the HTML.
+       For video URLs like YouTube, page metadata and video frames are complementary:
+       - url_context → upload date, uploader name, page title/description
+       - FileData → observable video content (speech, visuals, on-screen text)
     2. For each claim, assess whether each URL's content directly supports it
     3. Write a verification report
 

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -262,6 +262,8 @@ def inject_youtube_filedata(
     into the same parts array so Gemini can watch the videos inline.
     The original URLs are kept intact so url_context still fetches their
     title/description metadata.
+
+    Ref: https://ai.google.dev/gemini-api/docs/video-understanding#youtube
     """
     for content in llm_request.contents:
         if content.role != "user" or not content.parts:

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -10,6 +10,7 @@ This module implements a hierarchical agent system with:
 
 import asyncio
 import json
+import re
 import time
 from datetime import datetime
 from typing import Any, Dict, Optional
@@ -247,6 +248,43 @@ ai_investigator = LlmAgent(
 )
 
 
+_YOUTUBE_URL_RE = re.compile(
+    r"https?://(?:www\.)?(?:youtube\.com/watch\?[^\s]*v=|youtu\.be/)[^\s\"'<>]+"
+)
+
+
+def inject_youtube_filedata(
+    callback_context: CallbackContext, llm_request
+) -> None:
+    """Before-model callback for ai_verifier.
+
+    Scans the conversation contents for YouTube URLs and appends them as
+    FileData parts so Gemini can watch the videos. The original URLs are kept
+    intact so url_context still fetches their title/description metadata.
+    """
+    youtube_urls = []
+    for content in llm_request.contents:
+        if not content.parts:
+            continue
+        for part in content.parts:
+            if part.text:
+                youtube_urls.extend(_YOUTUBE_URL_RE.findall(part.text))
+
+    if not youtube_urls:
+        return None
+
+    llm_request.contents.append(
+        genai_types.Content(
+            role="user",
+            parts=[
+                genai_types.Part(file_data=genai_types.FileData(file_uri=url))
+                for url in dict.fromkeys(youtube_urls)  # deduplicate, preserve order
+            ],
+        )
+    )
+    return None
+
+
 # AI Verifier - Faithful passage reporter from URLs
 ai_verifier = LlmAgent(
     name="verifier",
@@ -255,13 +293,16 @@ ai_verifier = LlmAgent(
     #
     model="gemini-3-flash-preview",
     description="A fact-checking verifier. Give it URLs to read and claims to check — it reads all pages and returns a per-claim report showing which sources support or refute each claim, with verbatim quotes. Returns {content, sources} — content is the verification report; sources lists {title, url} pairs for all pages read.",
+    before_model_callback=inject_youtube_filedata,
     after_model_callback=append_url_context_sources,
     instruction="""
     You are an AI Verifier for fact-checking. Given a list of claims and a list of URLs,
     read all the URLs and determine which sources actually support each claim.
 
     ## Your Task
-    1. Use url_context to read all provided URLs in one call (up to 20)
+    1. Use url_context to read all provided URLs in one call (up to 20).
+       For YouTube URLs, the video content is already loaded in the context as well —
+       use what you see/hear in the video to verify claims, in addition to the page metadata.
     2. For each claim, assess whether each URL's content directly supports it
     3. Write a verification report
 

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -304,13 +304,11 @@ ai_verifier = LlmAgent(
     read all the URLs and determine which sources actually support each claim.
 
     ## Your Task
-    1. Call url_context for ALL provided URLs in one call (up to 20) — this is MANDATORY,
-       even when YouTube video content is already visible in this conversation.
-       url_context fetches the web PAGE and returns metadata that is NOT in the video frames:
-       upload date, publish date, uploader name, title, description.
-       Both sources are needed and serve different purposes:
-       - url_context → page metadata: uploadDate, uploader, title, description
-       - video (already in context) → content: what is visible/audible in the video
+    1. Call url_context for ALL provided URLs in one call (up to 20) — this is MANDATORY.
+       url_context fetches the web PAGE metadata (title, publish date, description), which is
+       always required regardless of what else is visible in this conversation.
+       Note: for video URLs (e.g. YouTube), page metadata and video frames are complementary —
+       url_context gives you the upload date; the video gives you observable content.
     2. For each claim, assess whether each URL's content directly supports it
     3. Write a verification report
 
@@ -338,9 +336,9 @@ ai_verifier = LlmAgent(
     or a person's full identity. If the video does not explicitly state it, write
     "影片未說明 / cannot be determined from this video."
 
-    **Three-layer reporting for YouTube URLs**: Always report all three layers in this order:
-    - 「頁面 metadata（url_context 取得）」: uploadDate/publishedAt, uploader channel name, video title — quoted verbatim from the page. The uploadDate is REQUIRED — a video can show old footage while being recently uploaded, and only the page metadata tells you when it was published online.
-    - 「影片標題/描述（上傳者提供）」: quote verbatim — present as what the uploader wrote, not as confirmed fact
+    **When video content is loaded in context**: Report three layers in this order:
+    - 「頁面 metadata（url_context 取得）」: uploadDate/publishedAt, uploader, title — quoted verbatim. uploadDate is REQUIRED: a video can show old footage while being recently uploaded, and only the page tells you when it was published online.
+    - 「影片標題/描述（上傳者提供）」: quote verbatim — treat as the uploader's claim, not confirmed fact
     - 「影片可觀察內容」: what is visible/audible in the video — speech, on-screen text, logos, surroundings
     The writer has broader context to judge whether the title is accurate or misleading.
 

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -353,7 +353,7 @@ ai_verifier = LlmAgent(
 # AI Proof-reader agents for different Taiwan political perspectives
 ai_proofreader_kmt = LlmAgent(
     name="proofreader_kmt",
-    model="gemini-3.1-flash-lite-preview",
+    model="gemini-3.1-flash-lite",
     generate_content_config=genai_types.GenerateContentConfig(
         thinking_config=genai_types.ThinkingConfig(
             thinking_level=genai_types.ThinkingLevel.HIGH
@@ -402,7 +402,7 @@ ai_proofreader_kmt = LlmAgent(
 
 ai_proofreader_dpp = LlmAgent(
     name="proofreader_dpp",
-    model="gemini-3.1-flash-lite-preview",
+    model="gemini-3.1-flash-lite",
     generate_content_config=genai_types.GenerateContentConfig(
         thinking_config=genai_types.ThinkingConfig(
             thinking_level=genai_types.ThinkingLevel.HIGH
@@ -451,7 +451,7 @@ ai_proofreader_dpp = LlmAgent(
 
 ai_proofreader_tpp = LlmAgent(
     name="proofreader_tpp",
-    model="gemini-3.1-flash-lite-preview",
+    model="gemini-3.1-flash-lite",
     generate_content_config=genai_types.GenerateContentConfig(
         thinking_config=genai_types.ThinkingConfig(
             thinking_level=genai_types.ThinkingLevel.HIGH
@@ -500,7 +500,7 @@ ai_proofreader_tpp = LlmAgent(
 
 ai_proofreader_minor_parties = LlmAgent(
     name="proofreader_minor_parties",
-    model="gemini-3.1-flash-lite-preview",
+    model="gemini-3.1-flash-lite",
     generate_content_config=genai_types.GenerateContentConfig(
         thinking_config=genai_types.ThinkingConfig(
             thinking_level=genai_types.ThinkingLevel.HIGH

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -249,7 +249,7 @@ ai_investigator = LlmAgent(
 
 
 _YOUTUBE_URL_RE = re.compile(
-    r"https?://(?:www\.)?(?:youtube\.com/watch\?[^\s]*v=|youtu\.be/)[^\s\"'<>]+"
+    r"https?://(?:www\.)?(?:youtube\.com/(?:watch\?[^\s]*v=|shorts/)|youtu\.be/)[^\s\"'<>]+"
 )
 
 

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -258,30 +258,25 @@ def inject_youtube_filedata(
 ) -> None:
     """Before-model callback for ai_verifier.
 
-    Scans the conversation contents for YouTube URLs and appends them as
-    FileData parts so Gemini can watch the videos. The original URLs are kept
-    intact so url_context still fetches their title/description metadata.
+    For each user message that contains YouTube URLs, appends FileData parts
+    into the same parts array so Gemini can watch the videos inline.
+    The original URLs are kept intact so url_context still fetches their
+    title/description metadata.
     """
-    youtube_urls = []
     for content in llm_request.contents:
-        if not content.parts:
+        if content.role != "user" or not content.parts:
             continue
+        youtube_urls = []
         for part in content.parts:
             if part.text:
                 youtube_urls.extend(_YOUTUBE_URL_RE.findall(part.text))
-
-    if not youtube_urls:
-        return None
-
-    llm_request.contents.append(
-        genai_types.Content(
-            role="user",
-            parts=[
-                genai_types.Part(file_data=genai_types.FileData(file_uri=url))
-                for url in dict.fromkeys(youtube_urls)  # deduplicate, preserve order
-            ],
-        )
-    )
+        seen = set()
+        for url in youtube_urls:
+            if url not in seen:
+                seen.add(url)
+                content.parts.append(
+                    genai_types.Part(file_data=genai_types.FileData(file_uri=url))
+                )
     return None
 
 

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -208,46 +208,6 @@ async def save_search_widget(
     return None
 
 
-# AI Web Searcher - Google Search snippet reporter
-ai_investigator = LlmAgent(
-    name="investigator",
-    # Reference: Gemini CLI is also using gemini-3-flash-preview for web-search
-    # https://github.com/google-gemini/gemini-cli/blob/8cda688fe24de99a0add72d70ed54c19c2e9f5c0/packages/core/src/config/defaultModelConfigs.ts#L185-L192
-    #
-    model="gemini-3-flash-preview",
-    description="A research assistant you can delegate fact-checking tasks to. Describe what you want to know or investigate; it will search the web, read results, and report back with detailed findings. Returns {content, sources, grounding_supports} — sources lists reliable {title, url} pairs; grounding_supports maps content passages to source indices.",
-    generate_content_config=genai_types.GenerateContentConfig(
-        thinking_config=genai_types.ThinkingConfig(
-            thinking_level=genai_types.ThinkingLevel.MEDIUM
-        )
-    ),
-    after_model_callback=[append_grounding_sources, save_search_widget],
-    instruction="""
-    You are an AI Investigator for fact-checking. Search the web and faithfully report
-    what search results say — do not draw conclusions or form opinions.
-
-    ## CRITICAL RULE — No URLs in Your Text
-    Never include any URL, hyperlink, or web address in your response text.
-    All source links are extracted automatically from search results by the system.
-    Putting URLs in your text would show unverified links to fact-checkers — a serious quality issue.
-
-    ## Your Task
-
-    1. Search Google for information relevant to the claim or question
-    2. For each relevant result, report the page title and its content in detail:
-       include specific facts, numbers, dates, names, and direct claims from the source.
-       The writer needs concrete information — not high-level summaries.
-    3. Skip results that are not directly relevant
-
-    ## Key Principles
-    - Report faithfully; do not analyze, synthesize, or editorialize
-    - The writer draws conclusions — your job is to relay what sources say
-    - If sources disagree, report both sides; let the writer reconcile
-    """,
-    tools=[google_search],
-)
-
-
 _YOUTUBE_URL_RE = re.compile(
     r"https?://(?:www\.)?(?:youtube\.com/(?:watch\?[^\s\"'<>]*v=|shorts/|live/|embed/|v/)|youtu\.be/)[^\s\"'<>]+"
 )
@@ -256,7 +216,7 @@ _YOUTUBE_URL_RE = re.compile(
 def inject_youtube_filedata(
     callback_context: CallbackContext, llm_request: Any
 ) -> None:
-    """Before-model callback for ai_verifier.
+    """Before-model callback for ai_investigator and ai_verifier.
 
     For each user message that contains YouTube URLs, appends FileData parts
     into the same parts array so Gemini can watch the videos inline.
@@ -280,6 +240,53 @@ def inject_youtube_filedata(
                     genai_types.Part(file_data=genai_types.FileData(file_uri=url))
                 )
     return None
+
+
+# AI Web Searcher - Google Search snippet reporter
+ai_investigator = LlmAgent(
+    name="investigator",
+    # Reference: Gemini CLI is also using gemini-3-flash-preview for web-search
+    # https://github.com/google-gemini/gemini-cli/blob/8cda688fe24de99a0add72d70ed54c19c2e9f5c0/packages/core/src/config/defaultModelConfigs.ts#L185-L192
+    #
+    model="gemini-3-flash-preview",
+    description="A research assistant you can delegate fact-checking tasks to. Describe what you want to know or investigate; it will search the web, read results, and report back with detailed findings. Returns {content, sources, grounding_supports} — sources lists reliable {title, url} pairs; grounding_supports maps content passages to source indices.",
+    generate_content_config=genai_types.GenerateContentConfig(
+        thinking_config=genai_types.ThinkingConfig(
+            thinking_level=genai_types.ThinkingLevel.MEDIUM
+        )
+    ),
+    before_model_callback=inject_youtube_filedata,
+    after_model_callback=[append_grounding_sources, save_search_widget],
+    instruction="""
+    You are an AI Investigator for fact-checking. Search the web and faithfully report
+    what search results say — do not draw conclusions or form opinions.
+
+    ## CRITICAL RULE — No URLs in Your Text
+    Never include any URL, hyperlink, or web address in your response text.
+    All source links are extracted automatically from search results by the system.
+    Putting URLs in your text would show unverified links to fact-checkers — a serious quality issue.
+
+    ## Your Task
+
+    1. Search Google for information relevant to the claim or question
+    2. For each relevant result, report the page title and its content in detail:
+       include specific facts, numbers, dates, names, and direct claims from the source.
+       The writer needs concrete information — not high-level summaries.
+    3. Skip results that are not directly relevant
+
+    ## Key Principles
+    - Report faithfully; do not analyze, synthesize, or editorialize
+    - The writer draws conclusions — your job is to relay what sources say
+    - If sources disagree, report both sides; let the writer reconcile
+
+    ## When a YouTube video is in context
+    If a YouTube video has been loaded into this conversation, first describe what you directly
+    observe (who appears, what is said, visible text and logos). Do NOT infer identity, event name,
+    or date from training knowledge — only from what is visible or audible. Then search the web
+    for corroborating information.
+    """,
+    tools=[google_search],
+)
 
 
 # AI Verifier - Faithful passage reporter from URLs
@@ -327,9 +334,11 @@ ai_verifier = LlmAgent(
     or a person's full identity. If the video does not explicitly state it, write
     "影片未說明 / cannot be determined from this video."
 
-    **Video title and hashtags are not evidence**: The title, description, and hashtags of a YouTube
-    video are added by the uploader and may be inaccurate or intentionally misleading.
-    Do NOT treat them as evidence about the event depicted in the video.
+    **Two-layer reporting for video content**: Report uploader-provided metadata and directly
+    observed content as separate, clearly labelled layers:
+    - 「影片標題/描述（上傳者提供）」: quote verbatim — present as what the uploader wrote, not as confirmed fact
+    - 「影片可觀察內容」: what is visible/audible in the video — speech, on-screen text, logos, surroundings
+    The writer has broader context to judge whether the title is accurate or misleading.
 
     **No invented citations**: The Sources list MUST ONLY contain URLs that were provided as input.
     Never cite a news article, report, or webpage that was not in the original URL list —

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -304,9 +304,13 @@ ai_verifier = LlmAgent(
     read all the URLs and determine which sources actually support each claim.
 
     ## Your Task
-    1. Use url_context to read all provided URLs in one call (up to 20).
-       For YouTube URLs, the video content is already loaded in the context as well —
-       use what you see/hear in the video to verify claims, in addition to the page metadata.
+    1. Call url_context for ALL provided URLs in one call (up to 20) — this is MANDATORY,
+       even when YouTube video content is already visible in this conversation.
+       url_context fetches the web PAGE and returns metadata that is NOT in the video frames:
+       upload date, publish date, uploader name, title, description.
+       Both sources are needed and serve different purposes:
+       - url_context → page metadata: uploadDate, uploader, title, description
+       - video (already in context) → content: what is visible/audible in the video
     2. For each claim, assess whether each URL's content directly supports it
     3. Write a verification report
 
@@ -334,8 +338,8 @@ ai_verifier = LlmAgent(
     or a person's full identity. If the video does not explicitly state it, write
     "影片未說明 / cannot be determined from this video."
 
-    **Two-layer reporting for video content**: Report uploader-provided metadata and directly
-    observed content as separate, clearly labelled layers:
+    **Three-layer reporting for YouTube URLs**: Always report all three layers in this order:
+    - 「頁面 metadata（url_context 取得）」: uploadDate/publishedAt, uploader channel name, video title — quoted verbatim from the page. The uploadDate is REQUIRED — a video can show old footage while being recently uploaded, and only the page metadata tells you when it was published online.
     - 「影片標題/描述（上傳者提供）」: quote verbatim — present as what the uploader wrote, not as confirmed fact
     - 「影片可觀察內容」: what is visible/audible in the video — speech, on-screen text, logos, surroundings
     The writer has broader context to judge whether the title is accurate or misleading.

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -249,12 +249,12 @@ ai_investigator = LlmAgent(
 
 
 _YOUTUBE_URL_RE = re.compile(
-    r"https?://(?:www\.)?(?:youtube\.com/(?:watch\?[^\s]*v=|shorts/)|youtu\.be/)[^\s\"'<>]+"
+    r"https?://(?:www\.)?(?:youtube\.com/(?:watch\?[^\s\"'<>]*v=|shorts/|live/|embed/|v/)|youtu\.be/)[^\s\"'<>]+"
 )
 
 
 def inject_youtube_filedata(
-    callback_context: CallbackContext, llm_request
+    callback_context: CallbackContext, llm_request: Any
 ) -> None:
     """Before-model callback for ai_verifier.
 


### PR DESCRIPTION
## Summary

Cofacts.ai often hallucinates or provides incomplete context when dealing with YouTube videos because it previously only relied on web metadata. This PR enables native video understanding for YouTube URLs across the agent system.

### YouTube Native Video Understanding
- **Automatic Injection**: Added `inject_youtube_filedata` as a `before_model_callback` for both `ai_verifier` and `ai_investigator`. It scans for YouTube URLs in the user messages and appends them as `FileData` parts, allowing Gemini to watch the videos directly.
- **Complementary Context**: Original URLs remain intact, so `url_context` (and Google Search grounding) continues to provide page-level metadata (titles, upload dates, descriptions) alongside the video frames.
- **Strict Instructions (Hard Rules)**: Updated instructions for `verifier` and `investigator` to enforce a "No Training Knowledge" policy for media. Agents are now required to report only what is directly visible/audible to prevent hallucinating identities or event details not present in the video.

### System Robustness & Upgrades
- **Model Stability**: Upgraded all proofreader agents from `gemini-3.1-flash-lite-preview` to the stable `gemini-3.1-flash-lite`.
- **Error Handling**: Implemented `handle_writer_tool_error` via `on_tool_error_callback` for the `ai_writer`. This prevents the entire session from crashing if a tool (like Google Search or url_context) fails, allowing the writer to react to the error message instead.

## Architecture

```
writer → investigator / verifier (input with youtube url)
              ↓ before_model_callback
              detect youtube urls in llm_request.contents
              append Content(role="user", parts=[FileData(file_uri=url)])
              ↓ model call
              url_context → youtube page HTML metadata (title, description)
              FileData    → Gemini watches video content directly
```

## Test Plan

https://langfuse.cofacts.tw/project/cmm0emerr0001qi07eugd0760/traces/3c3c0aa36707f8a1a05f2487a5fca052?timestamp=2026-05-30T07:29:47.923Z
- [x] Verified that YouTube URLs are correctly injected as `FileData` in LLM requests.   <img width="647" height="319" alt="圖片" src="https://github.com/user-attachments/assets/d81cbf24-7804-4f83-9777-1a584cc78839" />
- [x] Confirmed `ai_verifier` reports both page metadata (via `url_context`) and observable video content. <img width="673" height="438" alt="圖片" src="https://github.com/user-attachments/assets/e61a84b5-8a8f-423e-a010-8b638051fadd" />
- [x] Confirmed that regular web URLs still work as expected without `FileData` injection.
- [ ] Verify `ai_writer` gracefully handles tool errors in a live session.

---
_Generated by [Gemini CLI](https://github.com/google-gemini/gemini-cli)_