### PR TITLE
fix(verifier): require url_context for YouTube URLs to capture uploadDate

### DIFF
--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -304,13 +304,11 @@ ai_verifier = LlmAgent(
     read all the URLs and determine which sources actually support each claim.
 
     ## Your Task
-    1. Call url_context for ALL provided URLs in one call (up to 20) — this is MANDATORY,
-       even when YouTube video content is already visible in this conversation.
-       url_context fetches the web PAGE and returns metadata that is NOT in the video frames:
-       upload date, publish date, uploader name, title, description.
-       Both sources are needed and serve different purposes:
-       - url_context → page metadata: uploadDate, uploader, title, description
-       - video (already in context) → content: what is visible/audible in the video
+    1. Call url_context for ALL provided URLs in one call (up to 20) — this is MANDATORY.
+       url_context fetches the web PAGE metadata (title, publish date, description), which is
+       always required regardless of what else is visible in this conversation.
+       Note: for video URLs (e.g. YouTube), page metadata and video frames are complementary —
+       url_context gives you the upload date; the video gives you observable content.
     2. For each claim, assess whether each URL's content directly supports it
     3. Write a verification report
 
@@ -338,9 +336,9 @@ ai_verifier = LlmAgent(
     or a person's full identity. If the video does not explicitly state it, write
     "影片未說明 / cannot be determined from this video."
 
-    **Three-layer reporting for YouTube URLs**: Always report all three layers in this order:
-    - 「頁面 metadata（url_context 取得）」: uploadDate/publishedAt, uploader channel name, video title — quoted verbatim from the page. The uploadDate is REQUIRED — a video can show old footage while being recently uploaded, and only the page metadata tells you when it was published online.
-    - 「影片標題/描述（上傳者提供）」: quote verbatim — present as what the uploader wrote, not as confirmed fact
+    **When video content is loaded in context**: Report three layers in this order:
+    - 「頁面 metadata（url_context 取得）」: uploadDate/publishedAt, uploader, title — quoted verbatim. uploadDate is REQUIRED: a video can show old footage while being recently uploaded, and only the page tells you when it was published online.
+    - 「影片標題/描述（上傳者提供）」: quote verbatim — treat as the uploader's claim, not confirmed fact
     - 「影片可觀察內容」: what is visible/audible in the video — speech, on-screen text, logos, surroundings
     The writer has broader context to judge whether the title is accurate or misleading.
 

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -304,9 +304,13 @@ ai_verifier = LlmAgent(
     read all the URLs and determine which sources actually support each claim.
 
     ## Your Task
-    1. Use url_context to read all provided URLs in one call (up to 20).
-       For YouTube URLs, the video content is already loaded in the context as well —
-       use what you see/hear in the video to verify claims, in addition to the page metadata.
+    1. Call url_context for ALL provided URLs in one call (up to 20) — this is MANDATORY,
+       even when YouTube video content is already visible in this conversation.
+       url_context fetches the web PAGE and returns metadata that is NOT in the video frames:
+       upload date, publish date, uploader name, title, description.
+       Both sources are needed and serve different purposes:
+       - url_context → page metadata: uploadDate, uploader, title, description
+       - video (already in context) → content: what is visible/audible in the video
     2. For each claim, assess whether each URL's content directly supports it
     3. Write a verification report
 
@@ -334,8 +338,8 @@ ai_verifier = LlmAgent(
     or a person's full identity. If the video does not explicitly state it, write
     "影片未說明 / cannot be determined from this video."
 
-    **Two-layer reporting for video content**: Report uploader-provided metadata and directly
-    observed content as separate, clearly labelled layers:
+    **Three-layer reporting for YouTube URLs**: Always report all three layers in this order:
+    - 「頁面 metadata（url_context 取得）」: uploadDate/publishedAt, uploader channel name, video title — quoted verbatim from the page. The uploadDate is REQUIRED — a video can show old footage while being recently uploaded, and only the page metadata tells you when it was published online.
     - 「影片標題/描述（上傳者提供）」: quote verbatim — present as what the uploader wrote, not as confirmed fact
     - 「影片可觀察內容」: what is visible/audible in the video — speech, on-screen text, logos, surroundings
     The writer has broader context to judge whether the title is accurate or misleading.


### PR DESCRIPTION
## Problem

When verifying a YouTube Short, the verifier was skipping `url_context` entirely and relying only on the video frames loaded via `file_data` (injected by `inject_youtube_filedata` before_model_callback). Because video frames contain no page metadata, the `uploadDate` was never retrieved.

This caused a real failure in session https://langfuse.cofacts.tw/project/cmm0emerr0001qi07eugd0760/sessions/d1969b98-1928-4aab-b9ab-01d628b2c6c0
 : the video showed the annual 4/20 cannabis parade, but without knowing the upload date (May 2026) the agent assumed it was the 2024 edition rather than the 2026 one, leading to an incorrect fact-check conclusion.

## Root cause

The previous instruction said:
> "For YouTube URLs, the video content is already loaded in the context as well — use what you see/hear in the video to verify claims, in addition to the page metadata."

This wording gave the LLM permission to answer from `file_data` alone. The LLM saw the video and answered without ever calling `url_context`, so `uploadDate` never appeared in the output.

## Fix

- Step 1 now explicitly states `url_context` is **MANDATORY even when `file_data` is in context**, and explains why both are needed:
  - `url_context` → web page metadata: `uploadDate`, uploader, title, description
  - `file_data` (already in context) → video content: what is visible/audible

- "Two-layer reporting" expanded to **Three-layer reporting for YouTube URLs**:
  1. `「頁面 metadata（url_context 取得）」` — `uploadDate` is **required**
  2. `「影片標題/描述（上傳者提供）」` — verbatim uploader-provided metadata
  3. `「影片可觀察內容」` — directly observed video content

## Note

This PR is fast-forward merged on top of `claude/great-heisenberg-4eV14` (which introduced `inject_youtube_filedata`). The actual diff against that branch is just the instruction change in `ai_verifier`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDuKLZM1NSYEKkiQUBiNuU)_