### PR TITLE
fix: replace deprecated gemini-3.1-flash-lite-preview with gemini-3.1-flash-lite

### DIFF
--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -353,7 +353,7 @@ ai_verifier = LlmAgent(
 # AI Proof-reader agents for different Taiwan political perspectives
 ai_proofreader_kmt = LlmAgent(
     name="proofreader_kmt",
-    model="gemini-3.1-flash-lite-preview",
+    model="gemini-3.1-flash-lite",
     generate_content_config=genai_types.GenerateContentConfig(
         thinking_config=genai_types.ThinkingConfig(
             thinking_level=genai_types.ThinkingLevel.HIGH
@@ -402,7 +402,7 @@ ai_proofreader_kmt = LlmAgent(
 
 ai_proofreader_dpp = LlmAgent(
     name="proofreader_dpp",
-    model="gemini-3.1-flash-lite-preview",
+    model="gemini-3.1-flash-lite",
     generate_content_config=genai_types.GenerateContentConfig(
         thinking_config=genai_types.ThinkingConfig(
             thinking_level=genai_types.ThinkingLevel.HIGH
@@ -451,7 +451,7 @@ ai_proofreader_dpp = LlmAgent(
 
 ai_proofreader_tpp = LlmAgent(
     name="proofreader_tpp",
-    model="gemini-3.1-flash-lite-preview",
+    model="gemini-3.1-flash-lite",
     generate_content_config=genai_types.GenerateContentConfig(
         thinking_config=genai_types.ThinkingConfig(
             thinking_level=genai_types.ThinkingLevel.HIGH
@@ -500,7 +500,7 @@ ai_proofreader_tpp = LlmAgent(
 
 ai_proofreader_minor_parties = LlmAgent(
     name="proofreader_minor_parties",
-    model="gemini-3.1-flash-lite-preview",
+    model="gemini-3.1-flash-lite",
     generate_content_config=genai_types.GenerateContentConfig(
         thinking_config=genai_types.ThinkingConfig(
             thinking_level=genai_types.ThinkingLevel.HIGH


### PR DESCRIPTION
## Summary

- `gemini-3.1-flash-lite-preview` has been taken offline by Google, causing all 4 proofreader agents (`proofreader_kmt`, `proofreader_dpp`, `proofreader_tpp`, and the 4th at line 503) to return `404 NOT_FOUND` errors
- Updated all 4 agents in `adk/cofacts_ai/agent.py` to use `gemini-3.1-flash-lite`, the recommended GA replacement per Google's migration email

## Test plan

- [ ] Deploy and trigger a fact-check flow that invokes proofreaders
- [ ] Confirm no more `404 NOT_FOUND` errors for proofreader spans in Langfuse

---
_Generated by [Claude Code](https://claude.ai/code/session_01BpQncczuRMGnQvnHimJxLa)_