### PR TITLE
fix: forward user JWT to rumors-api so attachmentUrl is non-null for video/audio

### DIFF
--- a/adk/cofacts_ai/tools.py
+++ b/adk/cofacts_ai/tools.py
@@ -10,6 +10,7 @@ import json
 import asyncio
 from typing import Dict, List, Any, Optional
 import httpx
+from google.adk.tools.tool_context import ToolContext
 
 
 # GraphQL fragment for common Article fields
@@ -122,7 +123,8 @@ COMMON_ARTICLE_FIELDS = """
 async def _execute_cofacts_graphql(
     query: str,
     variables: Dict[str, Any],
-    operation_name: str = "GraphQL request"
+    operation_name: str = "GraphQL request",
+    auth_token: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Execute a GraphQL query against Cofacts API with standardized error handling.
@@ -131,10 +133,16 @@ async def _execute_cofacts_graphql(
         query: The GraphQL query string
         variables: Variables for the GraphQL query
         operation_name: Name of the operation for error reporting
+        auth_token: Optional JWT token issued by rumors-api for authenticated requests
 
     Returns:
         Response containing either data or error information
     """
+    headers: Dict[str, str] = {"Content-Type": "application/json"}
+    if auth_token:
+        headers["x-app-id"] = "RUMORS_SITE"
+        headers["Authorization"] = f"Bearer {auth_token}"
+
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.post(
@@ -143,9 +151,7 @@ async def _execute_cofacts_graphql(
                     "query": query,
                     "variables": variables
                 },
-                headers={
-                    "Content-Type": "application/json"
-                }
+                headers=headers,
             )
             response.raise_for_status()
 
@@ -174,7 +180,8 @@ async def search_cofacts_database(
     after: Optional[str] = None,
     reply_count_max: Optional[int] = None,
     days_back: Optional[int] = None,
-    order_by: str = "_score"
+    order_by: str = "_score",
+    tool_context: ToolContext = None,
 ) -> Dict[str, Any]:
     """
     Search the Cofacts database for articles using various filters.
@@ -285,7 +292,8 @@ async def search_cofacts_database(
         result = await _execute_cofacts_graphql(
             query=graphql_query,
             variables=variables,
-            operation_name="search Cofacts database"
+            operation_name="search Cofacts database",
+            auth_token=tool_context.state.get("temp:cofacts_token") if tool_context else None,
         )
 
         if "error" in result:
@@ -303,7 +311,8 @@ async def search_cofacts_database(
 
 
 async def get_single_cofacts_article(
-    article_id: str
+    article_id: str,
+    tool_context: ToolContext = None,
 ) -> Dict[str, Any]:
     """
     Get a single article from Cofacts database by ID.
@@ -335,7 +344,8 @@ async def get_single_cofacts_article(
         result = await _execute_cofacts_graphql(
             query=graphql_query,
             variables=variables,
-            operation_name="get specific Cofacts article"
+            operation_name="get specific Cofacts article",
+            auth_token=tool_context.state.get("temp:cofacts_token") if tool_context else None,
         )
 
         if "error" in result:

--- a/src/routes/api/run-sse.ts
+++ b/src/routes/api/run-sse.ts
@@ -1,9 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { getCookie } from '@tanstack/react-start/server'
 import type { components } from '@/lib/adk-types'
 import { ADK_APP_NAME, adkClient } from '@/lib/adkClient'
 import { handleAdkResponseError } from '@/lib/adk-errors'
 import { AUTH_EXPIRED_MESSAGE } from '@/lib/authExpired'
 import { resolveAdkUserIdOrThrow } from '@/server/adkUser'
+import { SESSION_COOKIE_NAME } from '@/server/sessionCookie'
 
 type RunRequest = components['schemas']['RunAgentRequest']
 type ChatInput = Omit<RunRequest, 'appName' | 'userId' | 'streaming'>
@@ -37,6 +39,7 @@ export const Route = createFileRoute('/api/run-sse')({
         }
 
         const input = (await request.json()) as ChatInput
+        const token = getCookie(SESSION_COOKIE_NAME)
 
         const { response } = await adkClient.POST('/run_sse', {
           parseAs: 'stream',
@@ -45,6 +48,7 @@ export const Route = createFileRoute('/api/run-sse')({
             appName: ADK_APP_NAME,
             userId,
             streaming: true,
+            stateDelta: token ? { 'temp:cofacts_token': token } : undefined,
           },
           // When the client aborts the fetch, request.signal fires (via srvx),
           // which in turn aborts the ADK SSE connection.


### PR DESCRIPTION
## Summary

- **Root cause:** The Python ADK tools (`search_cofacts_database`, `get_single_cofacts_article`) were making unauthenticated requests to `api.cofacts.tw/graphql`. For VIDEO/AUDIO articles, the `attachmentUrl(variant: PREVIEW)` resolver falls back to the `'original'` storage variant, which requires `user.appId === 'WEBSITE'` (set only when `x-app-id: RUMORS_SITE` + Bearer token are present). Without auth, it returns `null`, breaking the `inject_article_attachment` callback that converts signed GCS URLs to `gs://` URIs for Gemini media perception.
- **Fix in `run-sse.ts`:** Inject the session JWT (a rumors-api-issued token already in the BFF cookie) into each run request via `stateDelta` using the `temp:` prefix — accessible to tools within the request but **never persisted** to the session store or `/sessions` API.
- **Fix in `tools.py`:** Read `temp:cofacts_token` from `ToolContext` state and forward it as `Authorization: Bearer <token>` + `x-app-id: RUMORS_SITE` headers in `_execute_cofacts_graphql`, matching the pattern already used by `cofactsExec.ts` on the TypeScript side.

## Test plan

- [ ] Log in to cofacts.ai and open a Cofacts article that is VIDEO or AUDIO type
- [ ] Ask the AI to analyze it — `get_single_cofacts_article` response should now have a non-null `attachmentUrl`
- [ ] Confirm `inject_article_attachment` converts it to a `gs://` URI and Gemini receives the media
- [ ] Open an IMAGE article — verify `attachmentUrl` still works (no regression)
- [ ] IMAGE articles already worked unauthenticated (PREVIEW resolves to `IMAGE_PREVIEW` variant, no auth needed)

https://claude.ai/code/session_018aTTdyja1M2L37PGUYspem

---
_Generated by [Claude Code](https://claude.ai/code/session_018aTTdyja1M2L37PGUYspem)_