### PR TITLE
Handle missing grounding metadata in investigator/verifier drawer

### DIFF
--- a/src/components/RightDrawer.tsx
+++ b/src/components/RightDrawer.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import type { AllTools, ToolInvocation } from '@/lib/adk'
+import type { AllTools, ToolInvocation, ToolSource } from '@/lib/adk'
 
 interface RightDrawerProps {
   isOpen: boolean
@@ -142,7 +142,6 @@ function MarkdownSection({ content }: { content: string }) {
   )
 }
 
-type ToolSource = NonNullable<AllTools['investigator']['resp']['sources']>[number]
 
 function SourceCard({ source, index }: { source: ToolSource; index: number }) {
   const domain = source.url
@@ -186,8 +185,8 @@ function InvestigatorContent({
   args: AllTools['investigator']['args']
   response: AllTools['investigator']['resp'] | null
 }) {
-  const content = response?.content ?? response?.result ?? ''
-  const sources = response?.sources ?? []
+  const content = response ? ('content' in response ? response.content : response.result) : ''
+  const sources = response && 'content' in response ? response.sources : []
 
   return (
     <div className="flex-1 overflow-y-auto p-4 space-y-5">
@@ -232,8 +231,8 @@ function VerifierContent({
   args: AllTools['verifier']['args']
   response: AllTools['verifier']['resp'] | null
 }) {
-  const content = response?.content ?? response?.result ?? ''
-  const sources = response?.sources ?? []
+  const content = response ? ('content' in response ? response.content : response.result) : ''
+  const sources = response && 'content' in response ? response.sources : []
 
   return (
     <div className="flex-1 overflow-y-auto p-4 space-y-5">

--- a/src/components/RightDrawer.tsx
+++ b/src/components/RightDrawer.tsx
@@ -142,7 +142,7 @@ function MarkdownSection({ content }: { content: string }) {
   )
 }
 
-type ToolSource = { title: string; url: string }
+type ToolSource = NonNullable<AllTools['investigator']['resp']['sources']>[number]
 
 function SourceCard({ source, index }: { source: ToolSource; index: number }) {
   const domain = source.url

--- a/src/components/RightDrawer.tsx
+++ b/src/components/RightDrawer.tsx
@@ -142,7 +142,7 @@ function MarkdownSection({ content }: { content: string }) {
   )
 }
 
-type ToolSource = AllTools['investigator']['resp']['sources'][number]
+type ToolSource = { title: string; url: string }
 
 function SourceCard({ source, index }: { source: ToolSource; index: number }) {
   const domain = source.url
@@ -186,7 +186,7 @@ function InvestigatorContent({
   args: AllTools['investigator']['args']
   response: AllTools['investigator']['resp'] | null
 }) {
-  const content = response?.content ?? ''
+  const content = response?.content ?? response?.result ?? ''
   const sources = response?.sources ?? []
 
   return (
@@ -232,7 +232,7 @@ function VerifierContent({
   args: AllTools['verifier']['args']
   response: AllTools['verifier']['resp'] | null
 }) {
-  const content = response?.content ?? ''
+  const content = response?.content ?? response?.result ?? ''
   const sources = response?.sources ?? []
 
   return (

--- a/src/lib/adk.ts
+++ b/src/lib/adk.ts
@@ -30,6 +30,16 @@ export interface ChatMessage extends AdkContent {
   langfuseTraceId?: string
 }
 
+/** A source URL/title pair included in grounded investigator / verifier responses. */
+export type ToolSource = { title: string; url: string }
+
+/**
+ * ADK wraps a sub-agent's plain-text output as `{ result: string }` when the
+ * text cannot be parsed as JSON — e.g. when Gemini omits grounding metadata
+ * and the after-model callback falls back to a retry instruction or raw text.
+ */
+type AdkFallbackResp = { result: string }
+
 /**
  * Map of all cofacts_ai tool names to their `args` / `resp` shapes.
  *
@@ -40,23 +50,30 @@ export interface ChatMessage extends AdkContent {
 export type AllTools = {
   investigator: {
     args: { request?: string }
-    resp: {
-      content?: string
-      sources?: Array<{ title: string; url: string }>
-      grounding_supports?: Array<{
-        segment: { start_index: number; end_index: number; text: string }
-        source_ids: number[]
-      }>
-      result?: string // ADK fallback when grounding metadata is absent
-    }
+    /**
+     * Structured response when `google_search` returns grounding metadata.
+     * Falls back to `AdkFallbackResp` when Gemini omits grounding metadata
+     * intermittently (the callback injects a retry instruction as plain text).
+     */
+    resp:
+      | {
+          content: string
+          sources: Array<ToolSource>
+          grounding_supports: Array<{
+            segment: { start_index: number; end_index: number; text: string }
+            source_ids: number[]
+          }>
+        }
+      | AdkFallbackResp
   }
   verifier: {
     args: { request?: string }
-    resp: {
-      content?: string
-      sources?: Array<{ title: string; url: string }>
-      result?: string // ADK fallback when grounding metadata is absent
-    }
+    /**
+     * Structured response when `url_context` returns grounding metadata.
+     * Falls back to `AdkFallbackResp` when Gemini omits grounding metadata
+     * intermittently (the callback returns `None`, leaving raw LLM text).
+     */
+    resp: { content: string; sources: Array<ToolSource> } | AdkFallbackResp
   }
   proofreader_kmt: { args: { request?: string }; resp: { result: string } }
   proofreader_dpp: { args: { request?: string }; resp: { result: string } }

--- a/src/lib/adk.ts
+++ b/src/lib/adk.ts
@@ -41,17 +41,22 @@ export type AllTools = {
   investigator: {
     args: { request?: string }
     resp: {
-      content: string
-      sources: Array<{ title: string; url: string }>
-      grounding_supports: Array<{
+      content?: string
+      sources?: Array<{ title: string; url: string }>
+      grounding_supports?: Array<{
         segment: { start_index: number; end_index: number; text: string }
         source_ids: number[]
       }>
+      result?: string // ADK fallback when grounding metadata is absent
     }
   }
   verifier: {
     args: { request?: string }
-    resp: { content: string; sources: Array<{ title: string; url: string }> }
+    resp: {
+      content?: string
+      sources?: Array<{ title: string; url: string }>
+      result?: string // ADK fallback when grounding metadata is absent
+    }
   }
   proofreader_kmt: { args: { request?: string }; resp: { result: string } }
   proofreader_dpp: { args: { request?: string }; resp: { result: string } }


### PR DESCRIPTION
## Summary

- When Gemini intermittently omits `grounding_metadata`, `append_grounding_sources` returns plain-text retry instructions and `append_url_context_sources` returns `None` (raw LLM text). ADK wraps plain-text sub-agent output as `{result: string}` instead of the expected `{content, sources, ...}`, so `response.content` is `undefined` and both drawers render blank.
- Widened `investigator.resp` and `verifier.resp` in `AllTools` (`adk.ts`) to mark `content`, `sources`, and `grounding_supports` as optional and add `result?: string` for the ADK fallback shape.
- In `InvestigatorContent` and `VerifierContent` (`RightDrawer.tsx`), fall back to `response?.result` when `response?.content` is absent, so the text always renders as markdown.
- Fixed `ToolSource` type derivation (was derived from `sources[number]`; `sources` is now optional).

## Test plan

- [x] Normal case (grounding present): investigator/verifier drawer still shows structured content + source cards as before. <img width="1299" height="998" alt="圖片" src="https://github.com/user-attachments/assets/4a67fd09-4ede-4fa2-97bc-1f573ab5e15f" />
- [x] No-grounding case: drawer now shows the fallback text as markdown instead of being blank.  <img width="1918" height="1007" alt="圖片" src="https://github.com/user-attachments/assets/c6d09a5a-b131-46fd-9546-1c228d88ad73" />
- [x] `npm run build` / `tsc --noEmit` passes with no new type errors in changed files.
https://claude.ai/code/session_018FJEG1PKKJHxAa7AzHq7B1

---
_Generated by [Claude Code](https://claude.ai/code/session_018FJEG1PKKJHxAa7AzHq7B1)_