### PR TITLE
Pass auth token via Authorization header + ContextVar instead of session stateDelta

### DIFF
--- a/adk/Dockerfile
+++ b/adk/Dockerfile
@@ -13,4 +13,4 @@ COPY --from=builder /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 EXPOSE 8000
 ENV DATABASE_URL=sqlite+aiosqlite:////tmp/sessions.db
-CMD exec adk api_server --port 8000 --host 0.0.0.0 --session_service_uri=$DATABASE_URL .
+CMD exec python main.py

--- a/adk/cofacts_ai/auth_context.py
+++ b/adk/cofacts_ai/auth_context.py
@@ -1,0 +1,8 @@
+from contextvars import ContextVar
+from typing import Optional
+
+# Populated by the FastAPI middleware in main.py for each /run_sse request.
+# Tools read this directly instead of going through session state.
+cofacts_token_var: ContextVar[Optional[str]] = ContextVar(
+    "cofacts_token", default=None
+)

--- a/adk/cofacts_ai/tools.py
+++ b/adk/cofacts_ai/tools.py
@@ -12,8 +12,6 @@ import os
 from typing import Any, Dict, List, Optional
 
 import httpx
-from google.adk.tools.tool_context import ToolContext
-
 from .auth_context import cofacts_token_var
 
 # GraphQL fragment for common Article fields
@@ -184,7 +182,6 @@ async def search_cofacts_database(
     reply_count_max: Optional[int] = None,
     days_back: Optional[int] = None,
     order_by: str = "_score",
-    tool_context: ToolContext = None,
 ) -> Dict[str, Any]:
     """
     Search the Cofacts database for articles using various filters.
@@ -311,7 +308,6 @@ async def search_cofacts_database(
 
 async def get_single_cofacts_article(
     article_id: str,
-    tool_context: ToolContext = None,
 ) -> Dict[str, Any]:
     """
     Get a single article from Cofacts database by ID.

--- a/adk/cofacts_ai/tools.py
+++ b/adk/cofacts_ai/tools.py
@@ -14,6 +14,8 @@ from typing import Any, Dict, List, Optional
 import httpx
 from google.adk.tools.tool_context import ToolContext
 
+from .auth_context import cofacts_token_var
+
 # GraphQL fragment for common Article fields
 COMMON_ARTICLE_FIELDS = """
   fragment CommonArticleFields on Article {
@@ -292,7 +294,7 @@ async def search_cofacts_database(
             query=graphql_query,
             variables=variables,
             operation_name="search Cofacts database",
-            auth_token=tool_context.state.get("temp:cofacts_token") if tool_context else None,
+            auth_token=cofacts_token_var.get(),
         )
 
         if "error" in result:
@@ -342,7 +344,7 @@ async def get_single_cofacts_article(
             query=graphql_query,
             variables=variables,
             operation_name="get specific Cofacts article",
-            auth_token=tool_context.state.get("temp:cofacts_token") if tool_context else None,
+            auth_token=cofacts_token_var.get(),
         )
 
         if "error" in result:

--- a/adk/main.py
+++ b/adk/main.py
@@ -20,7 +20,7 @@ app = get_fast_api_app(
 @app.middleware("http")
 async def _inject_cofacts_token(request: Request, call_next):
     auth = request.headers.get("authorization", "")
-    token = auth.removeprefix("Bearer ").strip() or None
+    token = auth[7:].strip() or None if auth.lower().startswith("bearer ") else None
     t = cofacts_token_var.set(token)
     try:
         return await call_next(request)

--- a/adk/main.py
+++ b/adk/main.py
@@ -1,0 +1,36 @@
+import os
+
+import uvicorn
+from fastapi import Request
+from google.adk.cli.fast_api import get_fast_api_app
+
+from cofacts_ai.auth_context import cofacts_token_var
+
+_agents_dir = os.path.dirname(os.path.abspath(__file__))
+
+app = get_fast_api_app(
+    agents_dir=_agents_dir,
+    session_service_uri=os.environ.get(
+        "DATABASE_URL", "sqlite+aiosqlite:////tmp/sessions.db"
+    ),
+    web=False,
+)
+
+
+@app.middleware("http")
+async def _inject_cofacts_token(request: Request, call_next):
+    auth = request.headers.get("authorization", "")
+    token = auth.removeprefix("Bearer ").strip() or None
+    t = cofacts_token_var.set(token)
+    try:
+        return await call_next(request)
+    finally:
+        cofacts_token_var.reset(t)
+
+
+if __name__ == "__main__":
+    uvicorn.run(
+        app,
+        host=os.environ.get("HOST", "0.0.0.0"),
+        port=int(os.environ.get("PORT", "8000")),
+    )

--- a/adk/main.py
+++ b/adk/main.py
@@ -12,9 +12,7 @@ load_dotenv(os.path.join(_agents_dir, "cofacts_ai", ".env"))
 
 app = get_fast_api_app(
     agents_dir=_agents_dir,
-    session_service_uri=os.environ.get(
-        "DATABASE_URL", "sqlite+aiosqlite:////tmp/sessions.db"
-    ),
+    session_service_uri=os.environ.get("DATABASE_URL"),
     web=False,
 )
 

--- a/adk/main.py
+++ b/adk/main.py
@@ -1,12 +1,14 @@
 import os
 
 import uvicorn
+from dotenv import load_dotenv
 from fastapi import Request
 from google.adk.cli.fast_api import get_fast_api_app
 
 from cofacts_ai.auth_context import cofacts_token_var
 
 _agents_dir = os.path.dirname(os.path.abspath(__file__))
+load_dotenv(os.path.join(_agents_dir, "cofacts_ai", ".env"))
 
 app = get_fast_api_app(
     agents_dir=_agents_dir,

--- a/adk/pyproject.toml
+++ b/adk/pyproject.toml
@@ -15,4 +15,5 @@ dependencies = [
     "aiosqlite>=0.22.1",
     "sqlalchemy>=2.0.48",
     "asyncpg>=0.31.0",
+    "uvicorn>=0.41.0",
 ]

--- a/adk/uv.lock
+++ b/adk/uv.lock
@@ -291,6 +291,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "sqlalchemy" },
+    { name = "uvicorn" },
 ]
 
 [package.metadata]
@@ -306,6 +307,7 @@ requires-dist = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "sqlalchemy", specifier = ">=2.0.48" },
+    { name = "uvicorn", specifier = ">=0.41.0" },
 ]
 
 [[package]]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "concurrently \"pnpm run dev:ui\" \"pnpm run dev:agent\" --names ui,agent --prefix-colors blue,green --kill-others",
     "dev:ui": "vite dev --port 3000",
-    "dev:agent": "uv run --project adk adk web --port 8000 --reload_agents adk",
+    "dev:agent": "uv run --directory adk uvicorn main:app --port 8000 --reload --reload-dir cofacts_ai",
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",

--- a/src/routes/api/run-sse.ts
+++ b/src/routes/api/run-sse.ts
@@ -48,8 +48,8 @@ export const Route = createFileRoute('/api/run-sse')({
             appName: ADK_APP_NAME,
             userId,
             streaming: true,
-            stateDelta: token ? { 'temp:cofacts_token': token } : undefined,
           },
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
           // When the client aborts the fetch, request.signal fires (via srvx),
           // which in turn aborts the ADK SSE connection.
           signal: request.signal,


### PR DESCRIPTION
## Problem

The previous approach in `run-sse.ts` sent the Cofacts JWT as `stateDelta: { 'temp:cofacts_token': token }`. This never worked: ADK's `BaseSessionService.append_event` calls `_trim_temp_delta_state` which strips all `temp:` prefixed keys from the event before they reach `session.state`, so `tool_context.state.get("temp:cofacts_token")` always returned `None`.

## Root cause (traced through ADK source)

`temp:` state is designed to be set by **Python callbacks within an invocation** via `callback_context.state["temp:foo"] = bar` (which mutates `session.state` dict directly). When passed via the HTTP `stateDelta` field, it goes through `EventActions` → `append_event` → `_trim_temp_delta_state` → stripped, never lands in `session.state`.

## Solution

Use a `ContextVar` + FastAPI middleware instead:

1. **`adk/cofacts_ai/auth_context.py`** — defines `cofacts_token_var: ContextVar[Optional[str]]`
2. **`adk/main.py`** — replaces `adk api_server` CLI; adds an HTTP middleware that reads `Authorization: Bearer <token>` and sets the ContextVar
3. **`adk/cofacts_ai/tools.py`** — tools call `cofacts_token_var.get()` directly
4. **`src/routes/api/run-sse.ts`** — sends `Authorization: Bearer <token>` header instead of `stateDelta`
5. **`adk/Dockerfile`** — CMD changed to `python main.py`

### Why ContextVar propagates to tools

FastAPI middleware → `call_next` → Starlette's `BaseHTTPMiddleware` uses `anyio.create_task_group().start_soon(coro)`. Python asyncio automatically copies the current `contextvars` context into new tasks, so `cofacts_token_var` set in the middleware is visible everywhere in the request handling chain — including deep inside `runner.run_async` → tool functions.

No session state is touched; the token never appears in `list_sessions` responses.

## Test plan

- [ ] Start ADK server with `python main.py`
- [ ] Make a `/run_sse` request with a valid session cookie; confirm tools receive the token
- [ ] Verify Cofacts GraphQL calls with auth succeed (e.g. `submit_cofacts_reply`)
- [ ] Verify unauthenticated requests (no cookie) still work — tools receive `None` and make unauthenticated GraphQL calls as before

https://claude.ai/code/session_01Ke7rQW8p5rHtUk5Nm4HDFY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ke7rQW8p5rHtUk5Nm4HDFY)_