### PR TITLE
Improve writer orchestration discipline and source-coverage enforcement

### DIFF
--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -643,7 +643,7 @@ ai_writer = LlmAgent(
        - Identify factual statements vs. opinions in the message
        - If message contains opinions based on factual statements: prioritize verifying factual claims first
        - Determine target audience: people who might forward this message or receive it
-       - **Track editorial constraints**: whenever the user gives a constraint (e.g. "the video never uses the word X, so don't introduce it", "argue the necessity from a soldier's-usage angle", "the message never mentioned Y"), record it in a visible bullet list and carry it forward for the WHOLE conversation — never silently drop one. You will re-print and re-check this list before drafting (Step 7).
+       - **Track editorial constraints**: whenever the user gives a direction about HOW the reply should be written — a wording to avoid (e.g. "don't introduce a technical term the original message never used"), a framing or angle to take (e.g. "explain it from an ordinary reader's perspective"), or a tone/length preference (e.g. "keep it empathetic, not accusatory") — record it in a visible bullet list and carry it forward for the WHOLE conversation; never silently drop one. You will re-print and re-check this list before drafting (Step 7).
 
     3. **Political Perspective Check**: Get initial reactions from different political viewpoints on the suspicious message
 

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -304,6 +304,11 @@ ai_verifier = LlmAgent(
     #
     model="gemini-3-flash-preview",
     description="A fact-checking verifier. Give it URLs to read and claims to check — it reads all pages and returns a per-claim report showing which sources support or refute each claim, with verbatim quotes. Returns {content, sources} — content is the verification report; sources lists {title, url} pairs for all pages read.",
+    generate_content_config=genai_types.GenerateContentConfig(
+        thinking_config=genai_types.ThinkingConfig(
+            thinking_level=genai_types.ThinkingLevel.HIGH
+        )
+    ),
     before_model_callback=inject_youtube_filedata,
     after_model_callback=append_url_context_sources,
     instruction="""
@@ -629,10 +634,23 @@ ai_writer = LlmAgent(
     - Identifying factual statements vs. opinions
     - Checking for political blind spots using proofreader agents
     - Ensuring the final response is readable, neutral, and persuasive
-    - Not insisting on rigid processes; adapt to the user's workflow
+    - Following the user's lead on what to focus on next — while operating one step at a time (see Working Discipline below)
     - Providing gentle guidance to help them write responses their target audience can actually understand
 
     Focus on collaboration, not automation - the goal is human + AI working together.
+
+    ## Working Discipline (applies to EVERY turn — this overrides any "be flexible / adapt freely" wording elsewhere)
+
+    1. **One step at a time.** Call exactly ONE tool per turn unless the user explicitly asks you to do several things at once. After a tool returns, say in plain text what you learned and what you will do next, then stop — the next step runs on the next turn. Do NOT fan out multiple sub-agents in a single turn, and NEVER call `draft_factcheck_response` in the same turn as `investigator` or `verifier` (you cannot draft responsibly before their results are back). Going one step at a time keeps the human in the loop and stops you from jumping to conclusions.
+
+    2. **Watch the source before researching it.** You CANNOT see videos or page contents yourself — only `investigator` and `verifier` can. When the suspicious message centers on a video (e.g. a YouTube link) or its real claims live in a linked URL rather than in the article text, your FIRST research action is to delegate claim extraction: call `verifier` with that URL and ask it to "watch the video / read the page and enumerate every distinct factual claim it makes, verbatim where possible." Prefer `verifier` here because it both watches the video (via FileData) and reads page metadata such as upload date. Do not guess the message's claims, and do not start web searches, until you have this enumerated claim list.
+
+    3. **Maintain a running checklist and re-print it before every draft.** Keep a visible bullet list in your turn text — not only in your private thinking — that tracks:
+       - **Editorial constraints the user has given** (e.g. "the video never uses the word X, so don't introduce it", "argue the necessity from a soldier's-usage angle", "the message never mentioned Y"). Carry these forward for the WHOLE conversation; never silently drop one.
+       - **Open questions / claims not yet verifier-confirmed.**
+       Immediately before you call `draft_factcheck_response`, re-print this checklist and confirm each item is satisfied.
+
+    4. **No unverified claim in the draft.** A specific fact or number may appear in the reply ONLY if `verifier` returned ✓ for it against a specific URL. If `verifier` marked a claim ✗ (the given sources do not support it), you MUST either (a) drop the claim from the reply, or (b) find a DIFFERENT source and re-run `verifier` on it. NEVER re-submit the same URL — or relabel a different URL — for a claim the verifier already marked ✗.
 
     ## Getting Started:
 
@@ -667,13 +685,15 @@ ai_writer = LlmAgent(
 
     4. **Delegate Research**: Use the `investigator` to research claims
        - Describe what you want to know; investigator searches the web and reports findings with sources.
-       - **If the suspicious message contains URLs**: call `verifier` with those URLs and the message's key claims BEFORE further research. Viral messages frequently exaggerate, misattribute, or fabricate what their cited sources actually say — confirm the source says what the message claims before treating it as evidence.
+       - **If the suspicious message contains URLs / a video**: you should already have its claims from the claim-extraction step (Working Discipline #2). Viral messages frequently exaggerate, misattribute, or fabricate what their cited sources actually say — so treat those extracted claims as the message's *assertions*, not as confirmed facts, and verify them like any other claim.
        - **NO HALLUCINATION**: NEVER guess or invent a URL. Use only URLs from `sources[].url` returned by agents.
        - **INVESTIGATOR RESPONSE SCHEMA**: `investigator` returns `{{"content": "...", "sources": [...], "grounding_supports": [...]}}`.
          `sources` is a list of `{{"title": "...", "url": "..."}}` — the ONLY reliable URLs.
+         `grounding_supports` maps passages of `content` (by character offset) to indices into `sources[]`: this is how you know WHICH source backs WHICH statement — use it, do not guess the mapping. If a passage you want to cite has no `grounding_supports` entry, treat it as unsourced and send it to `verifier` before relying on it.
          Copy `url` exactly as returned — never retype or reconstruct a URL from memory. A URL you can write without looking at `sources` is a hallucination.
        - **VERIFIER RESPONSE SCHEMA**: `verifier` returns `{{"content": "...", "sources": [...]}}`.
          `content` is a per-claim verification report with verbatim quotes; `sources` lists all pages read.
+       - **Investigator DISCOVERS, verifier CONFIRMS.** `investigator` only finds candidate sources; `verifier` is the source of truth for which URL actually supports which claim. Your final citations come from `verifier`'s ✓ output, never from investigator's flat list alone (a long source list does not tell you which page says what).
 
     5. **REQUIRED: Source Verification** — After research is complete, call `verifier` with your key factual claims and the real `https://` source URLs from investigator's `sources[]`. This step is mandatory — do not skip it.
 
@@ -688,9 +708,10 @@ ai_writer = LlmAgent(
        - https://...
        ```
 
-       - Every specific fact or number you plan to cite in the reply must appear in verifier's output.
+       - Every specific fact or number you plan to cite in the reply must appear in verifier's output, marked ✓ against a specific URL.
        - Investigator summarizes pages and can err — verifier reads the originals directly.
        - Do not pass site names or descriptions; only real `https://` links.
+       - Build your final `references` and the `claim_sources` mapping (see `draft_factcheck_response`) ONLY from claims `verifier` marked ✓. Any claim verifier marked ✗ must be dropped or re-verified against a different source (Working Discipline #4) — do not carry it into the draft.
 
     6. **Draft & Proofreader Review**:
        - Write a draft reply in plain text (do NOT call the tool yet).
@@ -700,15 +721,15 @@ ai_writer = LlmAgent(
        - Repeat until you are satisfied with the draft and have addressed the proofreaders' key concerns.
 
     7. **Compose Reply**:
-       - Before calling the tool, explain your classification choice and the key points of the reply in text.
-       - Call `draft_factcheck_response` — this is the goal of the whole process. See the tool's argument descriptions for all format requirements.
+       - First re-print your running checklist (Working Discipline #3) and confirm every editorial constraint is met and every cited claim is verifier-confirmed.
+       - Then explain your classification choice and the key points of the reply in text.
+       - Call `draft_factcheck_response` — this is the goal of the whole process. See the tool's argument descriptions for all format requirements, including the `claim_sources` mapping (one entry per factual claim → the verifier-confirmed URL that backs it).
        - Use only claims confirmed by verifier in step 5.
        - Focus on persuading or kindly reminding people who share/receive such messages.
        - After the tool returns success, ask the user to open the tool call result above to review the draft and share any feedback.
 
-    **Flexible Support:**
-    - Offer sub-agent capabilities as needed, not as a rigid sequence
-    - Listen to what the user wants to focus on
+    **Flexible Support (within the Working Discipline above):**
+    - Listen to what the user wants to focus on, and follow their lead on sequencing — but still one step per turn
     - Provide verification support when asked
     - Help organize and structure their insights
     - Assist with formatting and presentation

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -634,23 +634,10 @@ ai_writer = LlmAgent(
     - Identifying factual statements vs. opinions
     - Checking for political blind spots using proofreader agents
     - Ensuring the final response is readable, neutral, and persuasive
-    - Following the user's lead on what to focus on next (see Working Discipline below)
+    - Following the user's lead on what to focus on next
     - Providing gentle guidance to help them write responses their target audience can actually understand
 
     Focus on collaboration, not automation - the goal is human + AI working together.
-
-    ## Working Discipline (applies to EVERY turn — this overrides any "be flexible / adapt freely" wording elsewhere)
-
-    1. **Draft only when everything else is done.** Running tools in parallel is fine — you may fan out several `investigator`, `proofreader`, or other sub-agent calls in one turn. The one hard rule: NEVER call `draft_factcheck_response` in the same turn as any other tool. Call it only after all research, verification, and proofreader review are complete and their results are back — drafting before then means concluding before you have the evidence.
-
-    2. **Watch the source before researching it.** You CANNOT see videos or page contents yourself — only `investigator` and `verifier` can. When the suspicious message centers on a video (e.g. a YouTube link) or its real claims live in a linked URL rather than in the article text, your FIRST research action is to delegate claim extraction: call `verifier` with that URL and ask it to "watch the video / read the page and enumerate every distinct factual claim it makes, verbatim where possible." Prefer `verifier` here because it both watches the video (via FileData) and reads page metadata such as upload date. Do not guess the message's claims, and do not start web searches, until you have this enumerated claim list.
-
-    3. **Maintain a running checklist and re-print it before every draft.** Keep a visible bullet list in your turn text — not only in your private thinking — that tracks:
-       - **Editorial constraints the user has given** (e.g. "the video never uses the word X, so don't introduce it", "argue the necessity from a soldier's-usage angle", "the message never mentioned Y"). Carry these forward for the WHOLE conversation; never silently drop one.
-       - **Open questions / claims not yet verifier-confirmed.**
-       Immediately before you call `draft_factcheck_response`, re-print this checklist and confirm each item is satisfied.
-
-    4. **No unverified claim in the draft.** A specific fact or number may appear in the reply ONLY if `verifier` returned ✓ for it against a specific URL. If `verifier` marked a claim ✗ (the given sources do not support it), you MUST either (a) drop the claim from the reply, or (b) find a DIFFERENT source and re-run `verifier` on it. NEVER re-submit the same URL — or relabel a different URL — for a claim the verifier already marked ✗.
 
     ## Getting Started:
 
@@ -677,15 +664,17 @@ ai_writer = LlmAgent(
        - Proceed with full fact-checking process
 
     2. **Claim Analysis & Strategy**:
+       - **If the message centers on a video or a linked URL whose claims are NOT in the article text**: your FIRST action is to delegate claim extraction — you cannot watch a video or read a page yourself, only `investigator`/`verifier` can. Call `verifier` with the URL and ask it to "watch the video / read the page and enumerate every distinct factual claim it makes, verbatim where possible" (prefer `verifier`: it both watches via FileData and reads page metadata such as upload date). Do not guess the message's claims, and do not start web searches, until you have this enumerated claim list.
        - Identify factual statements vs. opinions in the message
        - If message contains opinions based on factual statements: prioritize verifying factual claims first
        - Determine target audience: people who might forward this message or receive it
+       - **Track editorial constraints**: whenever the user gives a constraint (e.g. "the video never uses the word X, so don't introduce it", "argue the necessity from a soldier's-usage angle", "the message never mentioned Y"), record it in a visible bullet list and carry it forward for the WHOLE conversation — never silently drop one. You will re-print and re-check this list before drafting (Step 7).
 
     3. **Political Perspective Check**: Get initial reactions from different political viewpoints on the suspicious message
 
     4. **Delegate Research**: Use the `investigator` to research claims
        - Describe what you want to know; investigator searches the web and reports findings with sources.
-       - **If the suspicious message contains URLs / a video**: you should already have its claims from the claim-extraction step (Working Discipline #2). Viral messages frequently exaggerate, misattribute, or fabricate what their cited sources actually say — so treat those extracted claims as the message's *assertions*, not as confirmed facts, and verify them like any other claim.
+       - **If the suspicious message contains URLs / a video**: you should already have its claims from the claim-extraction step (Step 2). Viral messages frequently exaggerate, misattribute, or fabricate what their cited sources actually say — so treat those extracted claims as the message's *assertions*, not as confirmed facts, and verify them like any other claim.
        - **NO HALLUCINATION**: NEVER guess or invent a URL. Use only URLs from `sources[].url` returned by agents.
        - **INVESTIGATOR RESPONSE SCHEMA**: `investigator` returns `{{"content": "...", "sources": [...], "grounding_supports": [...]}}`.
          `sources` is a list of `{{"title": "...", "url": "..."}}` — the ONLY reliable URLs.
@@ -711,7 +700,7 @@ ai_writer = LlmAgent(
        - Every specific fact or number you plan to cite in the reply must appear in verifier's output, marked ✓ against a specific URL.
        - Investigator summarizes pages and can err — verifier reads the originals directly.
        - Do not pass site names or descriptions; only real `https://` links.
-       - Build your final `references` and the `claim_sources` mapping (see `draft_factcheck_response`) ONLY from claims `verifier` marked ✓. Any claim verifier marked ✗ must be dropped or re-verified against a different source (Working Discipline #4) — do not carry it into the draft.
+       - Build your final `references` and the `claim_sources` mapping (see `draft_factcheck_response`) ONLY from claims `verifier` marked ✓. A claim `verifier` marked ✗ (its sources do not support it) must be dropped or re-verified against a DIFFERENT source — NEVER re-submit the same URL or relabel a different URL for it, and never carry it into the draft.
 
     6. **Draft & Proofreader Review**:
        - Write a draft reply in plain text (do NOT call the tool yet).
@@ -720,15 +709,16 @@ ai_writer = LlmAgent(
        - Based on their feedback, revise the draft and re-send as needed.
        - Repeat until you are satisfied with the draft and have addressed the proofreaders' key concerns.
 
-    7. **Compose Reply**:
-       - First re-print your running checklist (Working Discipline #3) and confirm every editorial constraint is met and every cited claim is verifier-confirmed.
+    7. **Compose Reply — only after ALL research, verification, and proofreader review are complete**:
+       - **NEVER call `draft_factcheck_response` in the same turn as any other tool.** (Running other tools in parallel with each other is fine — e.g. several `investigator` or `proofreader` calls at once — but drafting must come last, after their results are back; drafting earlier means concluding before you have the evidence.)
+       - First re-print your tracked editorial-constraints list (from Step 2) and confirm every constraint is met and every cited claim is verifier-confirmed.
        - Then explain your classification choice and the key points of the reply in text.
        - Call `draft_factcheck_response` — this is the goal of the whole process. See the tool's argument descriptions for all format requirements, including the `claim_sources` mapping (one entry per factual claim → the verifier-confirmed URL that backs it).
        - Use only claims confirmed by verifier in step 5.
        - Focus on persuading or kindly reminding people who share/receive such messages.
        - After the tool returns success, ask the user to open the tool call result above to review the draft and share any feedback.
 
-    **Flexible Support (within the Working Discipline above):**
+    **Flexible Support:**
     - Listen to what the user wants to focus on, and follow their lead on sequencing
     - Provide verification support when asked
     - Help organize and structure their insights

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -678,7 +678,7 @@ ai_writer = LlmAgent(
        - **NO HALLUCINATION**: NEVER guess or invent a URL. Use only URLs from `sources[].url` returned by agents.
        - **INVESTIGATOR RESPONSE SCHEMA**: `investigator` returns `{{"content": "...", "sources": [...], "grounding_supports": [...]}}`.
          `sources` is a list of `{{"title": "...", "url": "..."}}` — the ONLY reliable URLs.
-         `grounding_supports` maps passages of `content` (by character offset) to indices into `sources[]`: this is how you know WHICH source backs WHICH statement — use it, do not guess the mapping. If a passage you want to cite has no `grounding_supports` entry, treat it as unsourced and send it to `verifier` before relying on it.
+         `grounding_supports` loosely associates passages of `content` with indices into `sources[]`. Treat it ONLY as a hint for which URLs *might* support a passage — it is NOT proof. Google's grounding routinely OVER-ATTRIBUTES: a single sentence is often tagged with many sources (we have seen 4–9), most of which do not actually contain that statement. So never cite a URL just because `grounding_supports` links it to a passage; use the hint only to choose which URLs to send to `verifier`, and let `verifier` (which reads the page) decide what each source really supports.
          Copy `url` exactly as returned — never retype or reconstruct a URL from memory. A URL you can write without looking at `sources` is a hallucination.
        - **VERIFIER RESPONSE SCHEMA**: `verifier` returns `{{"content": "...", "sources": [...]}}`.
          `content` is a per-claim verification report with verbatim quotes; `sources` lists all pages read.

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -634,14 +634,14 @@ ai_writer = LlmAgent(
     - Identifying factual statements vs. opinions
     - Checking for political blind spots using proofreader agents
     - Ensuring the final response is readable, neutral, and persuasive
-    - Following the user's lead on what to focus on next — while operating one step at a time (see Working Discipline below)
+    - Following the user's lead on what to focus on next (see Working Discipline below)
     - Providing gentle guidance to help them write responses their target audience can actually understand
 
     Focus on collaboration, not automation - the goal is human + AI working together.
 
     ## Working Discipline (applies to EVERY turn — this overrides any "be flexible / adapt freely" wording elsewhere)
 
-    1. **One step at a time.** Call exactly ONE tool per turn unless the user explicitly asks you to do several things at once. After a tool returns, say in plain text what you learned and what you will do next, then stop — the next step runs on the next turn. Do NOT fan out multiple sub-agents in a single turn, and NEVER call `draft_factcheck_response` in the same turn as `investigator` or `verifier` (you cannot draft responsibly before their results are back). Going one step at a time keeps the human in the loop and stops you from jumping to conclusions.
+    1. **Draft only when everything else is done.** Running tools in parallel is fine — you may fan out several `investigator`, `proofreader`, or other sub-agent calls in one turn. The one hard rule: NEVER call `draft_factcheck_response` in the same turn as any other tool. Call it only after all research, verification, and proofreader review are complete and their results are back — drafting before then means concluding before you have the evidence.
 
     2. **Watch the source before researching it.** You CANNOT see videos or page contents yourself — only `investigator` and `verifier` can. When the suspicious message centers on a video (e.g. a YouTube link) or its real claims live in a linked URL rather than in the article text, your FIRST research action is to delegate claim extraction: call `verifier` with that URL and ask it to "watch the video / read the page and enumerate every distinct factual claim it makes, verbatim where possible." Prefer `verifier` here because it both watches the video (via FileData) and reads page metadata such as upload date. Do not guess the message's claims, and do not start web searches, until you have this enumerated claim list.
 
@@ -729,7 +729,7 @@ ai_writer = LlmAgent(
        - After the tool returns success, ask the user to open the tool call result above to review the draft and share any feedback.
 
     **Flexible Support (within the Working Discipline above):**
-    - Listen to what the user wants to focus on, and follow their lead on sequencing — but still one step per turn
+    - Listen to what the user wants to focus on, and follow their lead on sequencing
     - Provide verification support when asked
     - Help organize and structure their insights
     - Assist with formatting and presentation

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -81,9 +81,8 @@ async def append_grounding_sources(
     """
     After-model callback for ai_investigator.
 
-    Transforms the raw LLM response into structured JSON {content, sources, grounding_supports}:
+    Transforms the raw LLM response into structured JSON {content, sources}:
     - Resolves grounding chunk redirect URLs in parallel; builds sources[] (1:1 with chunks)
-    - Preserves Gemini's grounding_supports segment positions for frontend visualization
     - If grounding metadata is missing (intermittent), injects a retry instruction for the writer
     - If response was blocked by copyright filter (RECITATION), injects a retry with different terms
     """
@@ -119,34 +118,11 @@ async def append_grounding_sources(
     # ── B: Build content from all text parts ─────────────────────────────────
     content = "".join(p.text or "" for p in llm_response.content.parts)
 
-    # ── C: Build grounding_supports preserving Gemini segment positions ──────
-    grounding_supports = []
-    seen_texts: set[str] = set()
-    for support in metadata.grounding_supports or []:
-        seg = support.segment
-        if not seg or not seg.text:
-            continue
-        if seg.text in seen_texts:
-            continue
-        seen_texts.add(seg.text)
-        src_ids = sorted(set(support.grounding_chunk_indices or []))
-        grounding_supports.append(
-            {
-                "segment": {
-                    "start_index": seg.start_index,
-                    "end_index": seg.end_index,
-                    "text": seg.text,
-                },
-                "source_ids": src_ids,
-            }
-        )
-
     # ── Write back as JSON so writer's after_tool_callback gets structured output
     serialized = json.dumps(
         {
             "content": content,
             "sources": sources_list,
-            "grounding_supports": grounding_supports,
         },
         ensure_ascii=False,
     )
@@ -160,9 +136,8 @@ async def append_url_context_sources(
     After-model callback for ai_verifier.
 
     Captures clean URL-title pairs from url_context grounding_chunks and wraps
-    the response as {content, sources} JSON. Intentionally omits grounding_supports
-    (too scattered for url_context). url_context returns real URLs directly —
-    no redirect resolution or hallucination stripping needed.
+    the response as {content, sources} JSON. url_context returns real URLs
+    directly — no redirect resolution or hallucination stripping needed.
     """
     if not llm_response.grounding_metadata:
         return None
@@ -256,7 +231,7 @@ ai_investigator = LlmAgent(
     # https://github.com/google-gemini/gemini-cli/blob/8cda688fe24de99a0add72d70ed54c19c2e9f5c0/packages/core/src/config/defaultModelConfigs.ts#L185-L192
     #
     model="gemini-3-flash-preview",
-    description="A research assistant you can delegate fact-checking tasks to. Describe what you want to know or investigate; it will search the web, read results, and report back with detailed findings. Returns {content, sources, grounding_supports} — sources lists reliable {title, url} pairs; grounding_supports maps content passages to source indices.",
+    description="A research assistant you can delegate fact-checking tasks to. Describe what you want to know or investigate; it will search the web, read results, and report back with detailed findings. Returns {content, sources} — sources lists reliable {title, url} pairs.",
     generate_content_config=genai_types.GenerateContentConfig(
         thinking_config=genai_types.ThinkingConfig(
             thinking_level=genai_types.ThinkingLevel.MEDIUM
@@ -676,9 +651,8 @@ ai_writer = LlmAgent(
        - Describe what you want to know; investigator searches the web and reports findings with sources.
        - **If the suspicious message contains URLs / a video**: you should already have its claims from the claim-extraction step (Step 2). Viral messages frequently exaggerate, misattribute, or fabricate what their cited sources actually say — so treat those extracted claims as the message's *assertions*, not as confirmed facts, and verify them like any other claim.
        - **NO HALLUCINATION**: NEVER guess or invent a URL. Use only URLs from `sources[].url` returned by agents.
-       - **INVESTIGATOR RESPONSE SCHEMA**: `investigator` returns `{{"content": "...", "sources": [...], "grounding_supports": [...]}}`.
-         `sources` is a list of `{{"title": "...", "url": "..."}}` — the ONLY reliable URLs.
-         `grounding_supports` loosely associates passages of `content` with indices into `sources[]`. Treat it ONLY as a hint for which URLs *might* support a passage — it is NOT proof. Google's grounding routinely OVER-ATTRIBUTES: a single sentence is often tagged with many sources (we have seen 4–9), most of which do not actually contain that statement. So never cite a URL just because `grounding_supports` links it to a passage; use the hint only to choose which URLs to send to `verifier`, and let `verifier` (which reads the page) decide what each source really supports.
+       - **INVESTIGATOR RESPONSE SCHEMA**: `investigator` returns `{{"content": "...", "sources": [...]}}`.
+         `sources` is a list of `{{"title": "...", "url": "..."}}` — the search results it found, and the ONLY reliable URLs. Treat them as CANDIDATES only: the `content` does not tell you which source actually backs which statement, so send the relevant `sources` URLs to `verifier` and let it (which reads each page) decide what each one really supports. Never cite a URL just because it appears in `sources`.
          Copy `url` exactly as returned — never retype or reconstruct a URL from memory. A URL you can write without looking at `sources` is a hallucination.
        - **VERIFIER RESPONSE SCHEMA**: `verifier` returns `{{"content": "...", "sources": [...]}}`.
          `content` is a per-claim verification report with verbatim quotes; `sources` lists all pages read.

--- a/adk/cofacts_ai/tools.py
+++ b/adk/cofacts_ai/tools.py
@@ -407,6 +407,7 @@ def draft_factcheck_response(
     classification: str,
     text: str,
     references: str,
+    claim_sources: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """
     Draft a Cofacts fact-check response for human editor review.
@@ -430,6 +431,18 @@ def draft_factcheck_response(
         references: Source references for the reply. Format: one source per line,
             each line is a URL followed by a one-line summary of what that source says.
             Only include URLs returned by investigator or verifier — never invent URLs.
+        claim_sources: Per-claim source coverage — REQUIRED unless classification is
+            "NOT_ARTICLE". One entry per distinct factual claim/number in `text`, each:
+            {
+              "claim": "<the factual claim or number as stated in text>",
+              "source_url": "<the URL that backs it — must also appear in references>",
+              "verifier_confirmed": true  // true ONLY if the verifier step returned ✓
+                                          // for this claim against this exact URL
+            }
+            This forces you to show which source backs which fact. The call is rejected
+            if any claim is not verifier_confirmed, or if a source_url is missing from
+            references — drop or re-verify such claims before drafting (do not relabel
+            a different URL for a claim the verifier marked ✗).
 
     Returns:
         {"success": True, "text": "..."} on success, or
@@ -457,6 +470,69 @@ def draft_factcheck_response(
                 "then call draft_factcheck_response again."
             ),
         }
+
+    # Per-claim source coverage gate. NOT_ARTICLE (out of scope) is exempt; every
+    # other classification — including OPINIONATED, which still cites real facts —
+    # must map each factual claim to a verifier-confirmed URL that is in references.
+    if classification != "NOT_ARTICLE":
+        if not claim_sources:
+            return {
+                "success": False,
+                "text": (
+                    "claim_sources is required for this classification. Provide one entry "
+                    "per factual claim/number in your reply, each "
+                    '{"claim": "...", "source_url": "...", "verifier_confirmed": true}, '
+                    "where verifier_confirmed is true only for claims the verifier marked ✓. "
+                    "Run the verifier step first if you have not, then call "
+                    "draft_factcheck_response again."
+                ),
+            }
+
+        malformed = []
+        unconfirmed = []
+        not_in_references = []
+        for entry in claim_sources:
+            if not isinstance(entry, dict):
+                malformed.append(str(entry))
+                continue
+            claim = str(entry.get("claim") or "").strip()
+            url = str(entry.get("source_url") or "").strip()
+            if not claim or not url:
+                malformed.append(json.dumps(entry, ensure_ascii=False))
+                continue
+            if entry.get("verifier_confirmed") is not True:
+                unconfirmed.append(claim)
+            if url not in references:
+                not_in_references.append(url)
+
+        if malformed:
+            return {
+                "success": False,
+                "text": (
+                    "Each claim_sources entry must be an object with non-empty 'claim' and "
+                    "'source_url'. Fix these entries and call draft_factcheck_response again: "
+                    + "; ".join(malformed)
+                ),
+            }
+        if unconfirmed:
+            return {
+                "success": False,
+                "text": (
+                    "These claims are not verifier-confirmed, so they cannot appear in the "
+                    "reply. Drop each one, OR verify it against a source with the verifier "
+                    "and set verifier_confirmed=true, then call draft_factcheck_response "
+                    "again: " + "; ".join(unconfirmed)
+                ),
+            }
+        if not_in_references:
+            return {
+                "success": False,
+                "text": (
+                    "These source_url values are not present in references. Add each source "
+                    "(URL + one-line summary) to references so the citation is visible, then "
+                    "call draft_factcheck_response again: " + "; ".join(not_in_references)
+                ),
+            }
 
     return {
         "success": True,

--- a/adk/cofacts_ai/tools.py
+++ b/adk/cofacts_ai/tools.py
@@ -488,6 +488,16 @@ def draft_factcheck_response(
                 ),
             }
 
+        # The leading token of each non-empty references line is the URL
+        # ("URL one-line-summary"); match against that set rather than a
+        # substring of the whole string (a short URL can be a substring of a
+        # longer listed one).
+        reference_urls = {
+            line.split(None, 1)[0]
+            for line in (ln.strip() for ln in references.splitlines())
+            if line
+        }
+
         malformed = []
         unconfirmed = []
         not_in_references = []
@@ -502,7 +512,7 @@ def draft_factcheck_response(
                 continue
             if entry.get("verifier_confirmed") is not True:
                 unconfirmed.append(claim)
-            if url not in references:
+            if url not in reference_urls:
                 not_in_references.append(url)
 
         if malformed:

--- a/src/lib/adk.ts
+++ b/src/lib/adk.ts
@@ -80,7 +80,16 @@ export type AllTools = {
   proofreader_tpp: { args: { request?: string }; resp: { result: string } }
   proofreader_minor_parties: { args: { request?: string }; resp: { result: string } }
   draft_factcheck_response: {
-    args: { classification?: string; text?: string; references?: string }
+    args: {
+      classification?: string
+      text?: string
+      references?: string
+      claim_sources?: Array<{
+        claim?: string
+        source_url?: string
+        verifier_confirmed?: boolean
+      }>
+    }
     resp: { success: boolean; text: string }
   }
   get_single_cofacts_article: {

--- a/src/lib/adk.ts
+++ b/src/lib/adk.ts
@@ -59,10 +59,6 @@ export type AllTools = {
       | {
           content: string
           sources: Array<ToolSource>
-          grounding_supports: Array<{
-            segment: { start_index: number; end_index: number; text: string }
-            source_ids: number[]
-          }>
         }
       | AdkFallbackResp
   }


### PR DESCRIPTION
## Background

Analysis of three real Langfuse sessions where a human fact-checker worked the **same** YouTube-Shorts-based message (Taiwan / ALTIUS drone procurement) surfaced repeated failure modes in the `writer`'s orchestration and the claim↔source data flow — *not* in the model's prose or the sub-agents (investigator/verifier worked fine). This PR fixes those.

Original observations

> Langfuse session ID [1878006f-c8c4-443d-968c-5a77db4dbe50](https://langfuse.cofacts.tw/project/cmm0emerr0001qi07eugd0760/sessions/1878006f-c8c4-443d-968c-5a77db4dbe50)
> Langfuse session ID [ebc732b2-9607-415d-8561-79bd0066403e](https://langfuse.cofacts.tw/project/cmm0emerr0001qi07eugd0760/sessions/ebc732b2-9607-415d-8561-79bd0066403e)
>
> 由於原始訊息是個 youtube shorts，cofacts article 本身並沒有所有該查證的 claim。然而， 兩次回應都有不主動使用 verifier 整理 video claim 的問題。
>
> 另外，兩次雖然都有呼叫 investigator，但後續的對話中，我三番兩次指出回應的出處沒有 cover 所有回應裡提出的數據與 factual claim、請他換出處等要求，但他的遵循度滿差的，感覺每次都回一樣的、有問題的出處。雖然回應寫得還行，但和我對話時提出的理想還是有若干差距，如應從軍人的角度來論述必要性、指出影片沒提及 LUCAS 這詞 (所以直接和 LUCAS 對比的話讀者會跟不上) 等等。
>
> 最後我受不了了，請他產出 handover prompt 後貼去 Gemini  Pro & claude Opus，再把結果貼回給 cofacts.ai 彙整：
Langfuse session ID [2d97c04f-eb5c-4461-a4c4-42187d6d3c2b](https://langfuse.cofacts.tw/project/cmm0emerr0001qi07eugd0760/sessions/2d97c04f-eb5c-4461-a4c4-42187d6d3c2b)
>
> 在這過程中我必須小心翼翼地使 cofacts.ai 一次只做一件事情，讓他不要太快跳到結論。但即使我給了兩個 AI 的完整調查結果，cofacts.ai 最後的出處還是沒有 cover 所有回應裡的 factual claim。


### Observed failure modes
1. **No proactive video-claim extraction** — the writer can't watch a video itself (only sub-agents can) and had no "extract claims first" step, so the human had to type "請 verifier 看影片整理 claims" every time.
2. **Premature drafting** — the writer drafted before/while research and verification were still running.
3. **References didn't cover all factual claims** — investigator returned a flat `sources[]` decoupled from prose, and `grounding_supports` over-attributed (measured **avg 4.5 sources per sentence, up to 9**; the over-cited claims were exactly the ones the verifier later marked unsupported). The writer guessed which URL backed which number and guessed wrong; even after the verifier marked claims ✗, the writer re-submitted the same/mislabeled sources. No coverage check existed in the draft tool.
4. **Dropped editorial/negative constraints** — e.g. the video never says "LUCAS", yet the reply kept framing around it.

## Changes

**`adk/cofacts_ai/agent.py`**
- **`verifier`: `thinking_level=HIGH`** (was unset/default — the most faithfulness-critical step had the smallest reasoning budget while flash-lite proofreaders ran HIGH).
- **`writer` prompt — discipline rules folded into the single `Orchestration Process`** (no separate block, single source of truth):
  - **Step 2** — *claim-extraction first*: when the message centers on a video/URL, the first action is to delegate claim enumeration to the `verifier` (it watches the video and reads page metadata); plus *track editorial constraints* in a running list.
  - **Step 5** — build `references`/`claim_sources` only from claims the verifier marked ✓; a ✗ claim must be dropped or re-verified against a different source.
  - **Step 7** — *draft last*: `draft_factcheck_response` is never called in the same turn as any other tool (other tools may still run in parallel with each other); re-print and re-check the editorial-constraints list before drafting.
- **investigator framing**: `sources[]` are *candidate* URLs to send to the verifier, not citations; the verifier (which reads the page) is the source of truth for which URL supports which claim. The permissive "not a rigid sequence" language was removed.
- **`grounding_supports` removed entirely** from the investigator output — Google's grounding over-attributes, its only consumer was the writer (no frontend renders it), and citations now come exclusively from the verifier. `append_grounding_sources` now returns `{content, sources}`.

**`adk/cofacts_ai/tools.py`**
- **`draft_factcheck_response`: per-claim coverage gate.** New `claim_sources` arg (`{claim, source_url, verifier_confirmed}`). The draft is rejected unless every factual claim maps to a `verifier_confirmed` URL that also appears in `references` (`NOT_ARTICLE` exempt). Per review feedback, the URL check parses the leading URL token of each `references` line and matches exactly (not a substring check).

**`src/lib/adk.ts`**
- draft args type extended with `claim_sources`; investigator response type drops `grounding_supports`.

## Not included (per maintainer decision)
- **Writer model swap.** flash is an acceptable baseline (prose was fine, sub-agents worked); follow-up is to make the writer model **manually switchable** and possibly auto-escalate by case complexity, decided via a flash-vs-pro A/B after these fixes land.

## Verification
- `python -m py_compile` passes; agent module imports cleanly (`verifier` thinking = HIGH; no `grounding_supports` in `agent.py`/`adk.ts`).
- Coverage gate unit-sanity-checked: missing / unconfirmed / url-not-in-references / malformed → rejected; well-formed and `NOT_ARTICLE` → accepted; substring false-positive → rejected.
- **End-to-end on a fresh run** (session `8d667352…`): tool order was `get_article → verifier (enumerate video claims) → investigator → proofreaders → verifier (verify) → proofreaders (review) → draft_factcheck_response (last, alone)`; the draft carried 3 `claim_sources`, all `verifier_confirmed=true` and present in `references`, and the gate returned `success:true`.

https://claude.ai/code/session_01DjdPjRtSyerB8SH9w1CQyt