### PR TITLE
refactor: chatCacheKey factory for TanStack Query chat cache key

### DIFF
--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -6,6 +6,7 @@ import type {
 import {
   INITIAL_CHAT_STATE,
   abortControllers,
+  chatCacheKey,
   convertAdkSessionToChatState,
   sendChatMessage,
   startChatStream,
@@ -21,7 +22,7 @@ interface UseChatOptions {
  */
 export function useChat({ sessionId }: UseChatOptions) {
   const queryClient = useQueryClient()
-  const queryKey = ['chat', sessionId]
+  const queryKey = chatCacheKey(sessionId)
 
   // Subscribe to the global store via TanStack Query
   const { data = INITIAL_CHAT_STATE, error: queryError } =

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 import { QueryClient } from '@tanstack/react-query'
 
 import { clearUserScopedCache } from '../auth'
+import { chatCacheKey } from '../chatCache'
 
 describe('clearUserScopedCache', () => {
   test('removes me / sessions / chat / feedback caches so an anonymous viewer cannot read prior user data', () => {
@@ -19,8 +20,8 @@ describe('clearUserScopedCache', () => {
       ['sessions'],
       [{ id: 's1', name: 'old', lastUpdateTime: 0 }],
     )
-    queryClient.setQueryData(['chat', 's1'], { messages: ['secret-1'] })
-    queryClient.setQueryData(['chat', 's2'], { messages: ['secret-2'] })
+    queryClient.setQueryData(chatCacheKey('s1'), { messages: ['secret-1'] })
+    queryClient.setQueryData(chatCacheKey('s2'), { messages: ['secret-2'] })
     queryClient.setQueryData(['feedback', 'trace-1', 'user-1'], {
       value: 1,
       comment: 'nice',
@@ -30,8 +31,8 @@ describe('clearUserScopedCache', () => {
 
     expect(queryClient.getQueryData(['me'])).toBeNull()
     expect(queryClient.getQueryData(['sessions'])).toBeUndefined()
-    expect(queryClient.getQueryData(['chat', 's1'])).toBeUndefined()
-    expect(queryClient.getQueryData(['chat', 's2'])).toBeUndefined()
+    expect(queryClient.getQueryData(chatCacheKey('s1'))).toBeUndefined()
+    expect(queryClient.getQueryData(chatCacheKey('s2'))).toBeUndefined()
     expect(
       queryClient.getQueryData(['feedback', 'trace-1', 'user-1']),
     ).toBeUndefined()

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -26,7 +26,7 @@ import { logout as logoutServerFn } from '@/server/auth.functions'
 import { getCurrentUserServerFn } from '@/server/me.functions'
 import { LoginModal } from '@/components/LoginModal'
 import { AUTH_EXPIRED_EVENT } from './authExpired'
-import { CHAT_CACHE_KEY_PREFIX } from './chatCache'
+import { chatCacheKey } from './chatCache'
 
 export type { CofactsUser }
 
@@ -39,7 +39,7 @@ const ME_QUERY_KEY = ['me'] as const
 export function clearUserScopedCache(queryClient: QueryClient) {
   queryClient.setQueryData(ME_QUERY_KEY, null)
   queryClient.removeQueries({ queryKey: ['sessions'] })
-  queryClient.removeQueries({ queryKey: CHAT_CACHE_KEY_PREFIX })
+  queryClient.removeQueries({ queryKey: chatCacheKey() })
   queryClient.removeQueries({ queryKey: ['feedback'] })
 }
 

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -26,6 +26,7 @@ import { logout as logoutServerFn } from '@/server/auth.functions'
 import { getCurrentUserServerFn } from '@/server/me.functions'
 import { LoginModal } from '@/components/LoginModal'
 import { AUTH_EXPIRED_EVENT } from './authExpired'
+import { CHAT_CACHE_KEY_PREFIX } from './chatCache'
 
 export type { CofactsUser }
 
@@ -38,7 +39,7 @@ const ME_QUERY_KEY = ['me'] as const
 export function clearUserScopedCache(queryClient: QueryClient) {
   queryClient.setQueryData(ME_QUERY_KEY, null)
   queryClient.removeQueries({ queryKey: ['sessions'] })
-  queryClient.removeQueries({ queryKey: ['chat'] })
+  queryClient.removeQueries({ queryKey: CHAT_CACHE_KEY_PREFIX })
   queryClient.removeQueries({ queryKey: ['feedback'] })
 }
 

--- a/src/lib/chatCache.ts
+++ b/src/lib/chatCache.ts
@@ -23,8 +23,11 @@ export const INITIAL_CHAT_STATE: ChatSessionState = {
   lastReplyDraftId: null,
 }
 
-export const chatCacheKey = (sessionId: string) => ['chat', sessionId] as const
-export const CHAT_CACHE_KEY_PREFIX = ['chat'] as const
+export function chatCacheKey(): readonly ['chat']
+export function chatCacheKey(sessionId: string): readonly ['chat', string]
+export function chatCacheKey(sessionId?: string) {
+  return sessionId ? (['chat', sessionId] as const) : (['chat'] as const)
+}
 
 // Global registry of abort controllers per session to prevent duplicate streams
 export const abortControllers = new Map<string, AbortController>()

--- a/src/lib/chatCache.ts
+++ b/src/lib/chatCache.ts
@@ -23,6 +23,9 @@ export const INITIAL_CHAT_STATE: ChatSessionState = {
   lastReplyDraftId: null,
 }
 
+export const chatCacheKey = (sessionId: string) => ['chat', sessionId] as const
+export const CHAT_CACHE_KEY_PREFIX = ['chat'] as const
+
 // Global registry of abort controllers per session to prevent duplicate streams
 export const abortControllers = new Map<string, AbortController>()
 
@@ -47,7 +50,7 @@ export async function startChatStream({
   sessionId,
   payload = {},
 }: StartStreamOptions) {
-  const queryKey = ['chat', sessionId]
+  const queryKey = chatCacheKey(sessionId)
 
   // Abort any existing stream for this session
   abortControllers.get(sessionId)?.abort()
@@ -166,7 +169,7 @@ export function sendChatMessage(
   sessionId: string,
   text: string,
 ) {
-  const queryKey = ['chat', sessionId]
+  const queryKey = chatCacheKey(sessionId)
 
   if (!queryClient.getQueryData(queryKey)) {
     queryClient.setQueryData(queryKey, INITIAL_CHAT_STATE)
@@ -373,7 +376,7 @@ function processEventIntoCache(
   sessionId: string,
   event: AdkEvent,
 ) {
-  queryClient.setQueryData<ChatSessionState>(['chat', sessionId], (prev) => {
+  queryClient.setQueryData<ChatSessionState>(chatCacheKey(sessionId), (prev) => {
     if (!prev) return INITIAL_CHAT_STATE
     return applyEventToState(prev, event)
   })


### PR DESCRIPTION
## Summary

- Add a single overloaded `chatCacheKey` factory to `chatCache.ts`:
  - `chatCacheKey()` → `['chat']` prefix (for `removeQueries`)
  - `chatCacheKey(sessionId)` → `['chat', sessionId]` full key
- Replace all inline `['chat', sessionId]` / `['chat']` literals across `chatCache.ts`, `useChat.ts`, `auth.tsx`, and `auth.test.ts`

Single source of truth for the query key structure — no more hunting across files if the key shape ever changes.

## Test plan

- [ ] `pnpm tsc --noEmit` passes (verified)
- [ ] Existing auth tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)