### PR TITLE
fix: skip functionCall parts during partial SSE events to fix RightDrawer blank result

### DIFF
--- a/src/lib/chatCache.ts
+++ b/src/lib/chatCache.ts
@@ -226,6 +226,10 @@ export function applyEventToState(
   let lastReplyDraftId = prev.lastReplyDraftId
 
   for (const part of event.content.parts) {
+    // Skip partial events: ADK assigns a fresh adk-<uuid> to every event via
+    // populate_client_function_call_id(), so partial and complete events get
+    // different IDs for the same call. Only the complete event's ID matches the
+    // session history and the incoming functionResponse.
     if (part.functionCall?.id && event.partial !== true) {
       const { id, name, args } = part.functionCall
       if (id && name) {
@@ -293,6 +297,9 @@ export function applyEventToState(
           id: genId(),
           role: 'model',
           author: event.author || 'writer',
+          // Exclude functionCall parts: they carry ephemeral adk-<uuid> IDs that
+          // differ from the canonical ID on the complete (partial: false) event.
+          // Badges are added once on the complete event so only canonical IDs appear.
           parts: eventParts.filter(p => !p.functionCall),
           isStreaming: event.partial !== false,
           timestamp: new Date(),
@@ -322,7 +329,7 @@ export function applyEventToState(
 
       for (const part of eventParts) {
         if (!part.text) {
-          if (part.functionCall) continue // skip — wait for canonical ID on complete event
+          if (part.functionCall) continue // ephemeral ID; canonical version added on complete event
           updatedParts.push({ ...part })
           continue
         }

--- a/src/lib/chatCache.ts
+++ b/src/lib/chatCache.ts
@@ -293,7 +293,7 @@ export function applyEventToState(
           id: genId(),
           role: 'model',
           author: event.author || 'writer',
-          parts: [...eventParts],
+          parts: eventParts.filter(p => !p.functionCall),
           isStreaming: event.partial !== false,
           timestamp: new Date(),
           langfuseTraceId: event.customMetadata?.['langfuse_trace_id'] as string | undefined,

--- a/src/lib/chatCache.ts
+++ b/src/lib/chatCache.ts
@@ -226,7 +226,7 @@ export function applyEventToState(
   let lastReplyDraftId = prev.lastReplyDraftId
 
   for (const part of event.content.parts) {
-    if (part.functionCall?.id) {
+    if (part.functionCall?.id && event.partial !== true) {
       const { id, name, args } = part.functionCall
       if (id && name) {
         toolInvocations[id] = {
@@ -302,13 +302,17 @@ export function applyEventToState(
     } else if (!event.partial) {
       // Last event still streaming but not this event, mark last event as not streaming.
       // ADK marks the end of streaming by setting `partial: false` with a full message.
-      // However, we have appended the streaming content to the last message in previous iterations,
-      // thus we can just reset the isStreaming flag of the previous message and drop this event.
+      // The streaming content was appended to the last message in previous iterations.
+      // We also append any functionCall parts now: we skipped them during partial events
+      // so that only the canonical adk-<uuid> IDs (from this complete event) are used.
+      const canonicalFCParts = eventParts.filter(p => p.functionCall)
+      const updatedParts = [...(last.parts ?? []), ...canonicalFCParts]
 
       messages = [
         ...messages.slice(0, -1),
         {
           ...last,
+          parts: updatedParts,
           isStreaming: false,
         },
       ]
@@ -318,7 +322,7 @@ export function applyEventToState(
 
       for (const part of eventParts) {
         if (!part.text) {
-          // Tool calls: push as is
+          if (part.functionCall) continue // skip — wait for canonical ID on complete event
           updatedParts.push({ ...part })
           continue
         }


### PR DESCRIPTION
## Summary

- **Bug**: Clicking a tool call badge in the chat after a streaming run always showed a blank RightDrawer; page refresh was required to see results.
- **Root cause**: ADK's progressive SSE streaming calls `populate_client_function_call_id()` on every event, assigning a fresh `adk-<uuid>` to each. Partial events get ephemeral IDs; the final complete event gets the canonical ID that matches the session history and tool responses. The frontend was recording and displaying badges for the ephemeral ID, while tool responses arrived for the canonical ID — leaving `toolInvocations[ephemeralId].resp === null`.  <img width="2035" height="1340" alt="image" src="https://github.com/user-attachments/assets/5710e3ee-cf65-40e4-a60f-63c692ec7d21" />
- **Fix** (3 targeted changes in `applyEventToState` in `src/lib/chatCache.ts`):
  1. Guard `toolInvocations` population with `event.partial !== true` — skip ephemeral IDs entirely.
  2. Skip `functionCall` parts when appending to a streaming message — hold off until the canonical ID arrives.
  3. On the complete event (`partial: false`), flush canonical `functionCall` parts into the message and `toolInvocations` together with the `isStreaming: false` flip.

## Test plan

- [x] Send a message that triggers tool calls (investigator, verifier, etc.) and watch the run complete
- [x] Click a tool call badge immediately after the run — RightDrawer should show the result without a page refresh
- [x] Confirm TanStack Query devtools no longer shows orphaned `resp: null` entries alongside canonical ones for the same tool
- [x] Confirm page refresh also works (cold cache via `convertAdkSessionToChatState`)

Tool response now shows after tool is done

https://github.com/user-attachments/assets/f03de91a-52e2-4363-835e-1fc91c3864e1


🤖 Generated with [Claude Code](https://claude.com/claude-code)