### PR TITLE
fix: preserve tool call badges after page refresh

### DIFF
--- a/src/lib/chatCache.ts
+++ b/src/lib/chatCache.ts
@@ -297,10 +297,12 @@ export function applyEventToState(
           id: genId(),
           role: 'model',
           author: event.author || 'writer',
-          // Exclude functionCall parts: they carry ephemeral adk-<uuid> IDs that
-          // differ from the canonical ID on the complete (partial: false) event.
-          // Badges are added once on the complete event so only canonical IDs appear.
-          parts: eventParts.filter(p => !p.functionCall),
+          // Partial events carry ephemeral adk-<uuid> IDs; exclude functionCall parts and
+          // wait for the canonical IDs from the complete event (handled in else-if branch).
+          // Complete events (including history replay) already have canonical IDs — include all.
+          parts: event.partial !== false
+            ? eventParts.filter(p => !p.functionCall)
+            : eventParts,
           isStreaming: event.partial !== false,
           timestamp: new Date(),
           langfuseTraceId: event.customMetadata?.['langfuse_trace_id'] as string | undefined,

--- a/src/lib/chatCache.ts
+++ b/src/lib/chatCache.ts
@@ -300,10 +300,10 @@ export function applyEventToState(
           // Partial events carry ephemeral adk-<uuid> IDs; exclude functionCall parts and
           // wait for the canonical IDs from the complete event (handled in else-if branch).
           // Complete events (including history replay) already have canonical IDs — include all.
-          parts: event.partial !== false
+          parts: event.partial === true
             ? eventParts.filter(p => !p.functionCall)
             : eventParts,
-          isStreaming: event.partial !== false,
+          isStreaming: event.partial === true,
           timestamp: new Date(),
           langfuseTraceId: event.customMetadata?.['langfuse_trace_id'] as string | undefined,
         },


### PR DESCRIPTION
## Summary

- Tool call badges (functionCall parts) disappeared from chat messages after page refresh
- Root cause: `applyEventToState()` always filtered out `functionCall` parts when creating a new message, relying on the "complete streaming" branch to add them back — but that branch only fires when `last.isStreaming === true`, which never happens during history replay
- Fix: only filter `functionCall` parts for partial events (ephemeral IDs); complete events (including history replay) include all parts directly

## Test plan

- [x] Start a session with tool calls, confirm badges appear during streaming
- [x] Load a previous session, confirm badges still appear after reload 

https://github.com/user-attachments/assets/7372296d-297a-4d89-9777-0f59a49d95e1

https://claude.ai/code/session_01N28Vc9DGzABXxS6BUbrYbs

---
_Generated by [Claude Code](https://claude.ai/code/session_01N28Vc9DGzABXxS6BUbrYbs)_