### PR TITLE
feat: support OS drag-and-drop file upload in chat input

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -28,6 +28,7 @@ export function ChatInput({
 }: ChatInputProps) {
   const [value, setValue] = useState(() => drafts.get(sessionId) ?? '')
   const [files, setFiles] = useState<Array<File>>([])
+  const [isDragging, setIsDragging] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -68,6 +69,35 @@ export function ChatInput({
     setFiles((prev) => prev.filter((_, i) => i !== index))
   }, [])
 
+  const handleDragOver = useCallback(
+    (e: React.DragEvent) => {
+      if (disabled || isStreaming) return
+      if (!e.dataTransfer.types.includes('Files')) return
+      e.preventDefault()
+      e.stopPropagation()
+      setIsDragging(true)
+    },
+    [disabled, isStreaming],
+  )
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    if (!(e.currentTarget as Element).contains(e.relatedTarget as Node)) {
+      setIsDragging(false)
+    }
+  }, [])
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      setIsDragging(false)
+      if (disabled || isStreaming) return
+      const dropped = Array.from(e.dataTransfer.files)
+      if (dropped.length > 0) setFiles((prev) => [...prev, ...dropped])
+    },
+    [disabled, isStreaming],
+  )
+
   useBlocker({
     shouldBlockFn: () => false,
     enableBeforeUnload: () =>
@@ -86,7 +116,21 @@ export function ChatInput({
 
   return (
     <div className="px-3 md:px-4 pb-3 md:pb-4 pt-2 bg-white shrink-0 z-10">
-      <div className="rounded-xl shadow-sm border border-gray-300 bg-white focus-within:ring-2 focus-within:ring-primary focus-within:border-primary transition-all">
+      <div
+        className={`relative rounded-xl shadow-sm border bg-white focus-within:ring-2 focus-within:ring-primary focus-within:border-primary transition-all ${isDragging ? 'border-primary ring-2 ring-primary' : 'border-gray-300'}`}
+        onDragOver={handleDragOver}
+        onDragEnter={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        {isDragging && (
+          <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-1 rounded-xl bg-white/90 pointer-events-none">
+            <span className="material-symbols-outlined text-3xl text-primary">
+              upload_file
+            </span>
+            <span className="text-sm text-primary font-medium">放開以附加檔案</span>
+          </div>
+        )}
         {/* Row 1: text input */}
         <textarea
           ref={textareaRef}

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -72,7 +72,7 @@ export function ChatInput({
   const handleDragOver = useCallback(
     (e: React.DragEvent) => {
       if (disabled || isStreaming) return
-      if (!e.dataTransfer.types.includes('Files')) return
+      if (!e.dataTransfer?.types?.includes('Files')) return
       e.preventDefault()
       e.stopPropagation()
       setIsDragging(true)
@@ -81,7 +81,8 @@ export function ChatInput({
   )
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {
-    if (!(e.currentTarget as Element).contains(e.relatedTarget as Node)) {
+    const related = e.relatedTarget
+    if (!(related instanceof Node) || !(e.currentTarget as Element).contains(related)) {
       setIsDragging(false)
     }
   }, [])
@@ -92,7 +93,9 @@ export function ChatInput({
       e.stopPropagation()
       setIsDragging(false)
       if (disabled || isStreaming) return
-      const dropped = Array.from(e.dataTransfer.files)
+      const dtFiles = e.dataTransfer?.files
+      if (!dtFiles) return
+      const dropped = Array.from(dtFiles)
       if (dropped.length > 0) setFiles((prev) => [...prev, ...dropped])
     },
     [disabled, isStreaming],
@@ -117,13 +120,13 @@ export function ChatInput({
   return (
     <div className="px-3 md:px-4 pb-3 md:pb-4 pt-2 bg-white shrink-0 z-10">
       <div
-        className={`relative rounded-xl shadow-sm border bg-white focus-within:ring-2 focus-within:ring-primary focus-within:border-primary transition-all ${isDragging ? 'border-primary ring-2 ring-primary' : 'border-gray-300'}`}
+        className={`relative rounded-xl shadow-sm border bg-white focus-within:ring-2 focus-within:ring-primary focus-within:border-primary transition-all ${isDragging && !disabled && !isStreaming ? 'border-primary ring-2 ring-primary' : 'border-gray-300'}`}
         onDragOver={handleDragOver}
         onDragEnter={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
       >
-        {isDragging && (
+        {isDragging && !disabled && !isStreaming && (
           <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-1 rounded-xl bg-white/90 pointer-events-none">
             <span className="material-symbols-outlined text-3xl text-primary">
               upload_file


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds drag-and-drop support to the chat input box: dragging files from the OS file manager onto the input area queues them as attachments
- A visual overlay with an upload icon and "放開以附加檔案" label appears while files are held over the drop zone
- Dropped files are appended to any already-queued attachments, same as clicking the paperclip button
- Drag-and-drop is disabled when the input is disabled or streaming

## Test plan

- [x] Drag a single image/PDF from the file manager onto the chat input — overlay appears, file appears as a pill after drop 

    https://github.com/user-attachments/assets/2dc0142a-d7e6-4086-bc18-db4196c85d03

- [x] Drag multiple files at once — all appear as pills
- [x] Drag files over while streaming — overlay does not appear, files are not added

    https://github.com/user-attachments/assets/aded0296-4b6a-430c-9f80-f3cad7dc621f

- [x] Drag a file then drag another — both accumulate
- [x] Drag something that's not a file (e.g. selected text from browser) — overlay does not appear

https://claude.ai/code/session_016xCcRkJBGihwmTAgm3RArK
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016xCcRkJBGihwmTAgm3RArK)_