### PR TITLE
feat: support pasting images from clipboard in chat input

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -30,6 +30,7 @@ export function ChatInput({
   const [files, setFiles] = useState<Array<File>>([])
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const pasteCounter = useRef(0)
 
   // Auto-resize textarea
   useEffect(() => {
@@ -64,6 +65,24 @@ export function ChatInput({
     [],
   )
 
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      const imageFiles = Array.from(e.clipboardData.items)
+        .filter((item) => item.kind === 'file' && item.type.startsWith('image/'))
+        .map((item) => {
+          const file = item.getAsFile()!
+          pasteCounter.current += 1
+          return new File([file], `Pasted image ${pasteCounter.current}`, {
+            type: file.type,
+          })
+        })
+      if (imageFiles.length > 0) {
+        setFiles((prev) => [...prev, ...imageFiles])
+      }
+    },
+    [],
+  )
+
   const removeFile = useCallback((index: number) => {
     setFiles((prev) => prev.filter((_, i) => i !== index))
   }, [])
@@ -92,6 +111,7 @@ export function ChatInput({
           ref={textareaRef}
           value={value}
           onChange={(e) => handleChange(e.target.value)}
+          onPaste={handlePaste}
           onKeyDown={(e) => {
             if (
               e.key === 'Enter' &&

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -67,17 +67,26 @@ export function ChatInput({
 
   const handlePaste = useCallback(
     (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
-      const imageFiles = Array.from(e.clipboardData.items)
-        .filter((item) => item.kind === 'file' && item.type.startsWith('image/'))
-        .map((item) => {
-          const file = item.getAsFile()!
-          pasteCounter.current += 1
-          return new File([file], `Pasted image ${pasteCounter.current}`, {
-            type: file.type,
-          })
-        })
+      const imageFiles: File[] = []
+      for (const item of Array.from(e.clipboardData.items)) {
+        if (item.kind === 'file' && item.type.startsWith('image/')) {
+          const file = item.getAsFile()
+          if (file) {
+            pasteCounter.current += 1
+            const ext = file.type.split('/')[1] || 'png'
+            imageFiles.push(
+              new File(
+                [file],
+                `Pasted image ${pasteCounter.current}.${ext}`,
+                { type: file.type },
+              ),
+            )
+          }
+        }
+      }
       if (imageFiles.length > 0) {
         setFiles((prev) => [...prev, ...imageFiles])
+        e.preventDefault()
       }
     },
     [],


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `onPaste` handler to the chat textarea in `ChatInput.tsx`
- Detects image files in clipboard data (`clipboardData.items`) and appends them as `File` objects
- Pasted images are named "Pasted image 1", "Pasted image 2", etc.
- Pasted images flow through the exact same upload pipeline as file-picker attachments (base64 → `SaveFilesAsArtifactsPlugin` → artifact store)

## Test plan

- [x] Focus the textarea, copy an image to clipboard, paste (Ctrl+V / ⌘V) → pill "Pasted image 1" appears
- [x] Paste again → "Pasted image 2" appears
- [x] Send the message → image is visible as inline preview in the user bubble
- [x] File picker upload still works unchanged
- [x] Pasting plain text still works normally (no extra pills)

https://claude.ai/code/session_016m1gpCeYMUSPFCJygVn2aj
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016m1gpCeYMUSPFCJygVn2aj)_