### PR TITLE
fix: add administration:write permission to preview-cleanup workflow

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -8,6 +8,7 @@ permissions:
   contents: read
   id-token: write
   deployments: write
+  administration: write
 
 jobs:
   cleanup:


### PR DESCRIPTION
Fixes #45

## Root cause

The `deleteAnEnvironment` GitHub API endpoint requires `administration=write` permission (confirmed from the 403 response header: `x-accepted-github-permissions: administration=write`). The `preview-cleanup.yml` workflow was missing this permission, causing all cleanup runs to fail with:

```
HttpError: Resource not accessible by integration (403)
```

## Fix

Added `administration: write` to the `permissions` block in `.github/workflows/preview-cleanup.yml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UE511cMg9nN3LneAcNFLP7)_