### PR TITLE
fix: switch investigator and verifier to GA model gemini-3.1-flash-lite

### DIFF
--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -218,10 +218,9 @@ def inject_youtube_filedata(
 # AI Web Searcher - Google Search snippet reporter
 ai_investigator = LlmAgent(
     name="investigator",
-    # Reference: Gemini CLI is also using gemini-3-flash-preview for web-search
-    # https://github.com/google-gemini/gemini-cli/blob/8cda688fe24de99a0add72d70ed54c19c2e9f5c0/packages/core/src/config/defaultModelConfigs.ts#L185-L192
-    #
-    model="gemini-3-flash-preview",
+    # Use GA model for stability; gemini-3-flash-preview (preview) occasionally
+    # exceeds Vertex AI's ~125s server-side limit causing silent empty responses.
+    model="gemini-3.1-flash-lite",
     description="A research assistant you can delegate fact-checking tasks to. Describe what you want to know or investigate; it will search the web, read results, and report back with detailed findings. Returns {content, sources} — sources lists reliable {title, url} pairs.",
     generate_content_config=genai_types.GenerateContentConfig(
         thinking_config=genai_types.ThinkingConfig(
@@ -265,10 +264,9 @@ ai_investigator = LlmAgent(
 # AI Verifier - Faithful passage reporter from URLs
 ai_verifier = LlmAgent(
     name="verifier",
-    # Reference: Gemini CLI is also using gemini-3-flash-preview for web-fetch
-    # https://github.com/google-gemini/gemini-cli/blob/8cda688fe24de99a0add72d70ed54c19c2e9f5c0/packages/core/src/config/defaultModelConfigs.ts#L193-L200
-    #
-    model="gemini-3-flash-preview",
+    # Use GA model for stability; gemini-3-flash-preview (preview) occasionally
+    # exceeds Vertex AI's ~125s server-side limit causing silent empty responses.
+    model="gemini-3.1-flash-lite",
     description="A fact-checking verifier. Give it URLs to read and claims to check — it reads all pages and returns a per-claim report showing which sources support or refute each claim, with verbatim quotes. Returns {content, sources} — content is the verification report; sources lists {title, url} pairs for all pages read.",
     generate_content_config=genai_types.GenerateContentConfig(
         thinking_config=genai_types.ThinkingConfig(


### PR DESCRIPTION
## Problem

As noted in #98, `investigator` and `verifier` agents were using `gemini-3-flash-preview`, a preview model that occasionally exceeds Vertex AI's ~125s server-side processing limit. This causes silent empty responses and repeated failures.

## Fix

Switch both `ai_investigator` and `ai_verifier` from `gemini-3-flash-preview` to `gemini-3.1-flash-lite`, which is already GA. The other agents in this codebase (`ai_writer`'s sub-agents) already use `gemini-3.1-flash-lite`.

## Changes

- `adk/cofacts_ai/agent.py`: Update `model=` for `ai_investigator` and `ai_verifier`; update comments to explain the rationale

## Test plan

- [ ] Deploy and observe Langfuse sessions — investigator and verifier should no longer produce empty responses or stall for 300s+
- [ ] Confirm normal fact-check flows complete successfully with the new model

---
_Generated by [Claude Code](https://claude.ai/code/session_013VsWoAmh1m2bey7NRjQRtY)_