### PR TITLE
feat(session): auto-generate session title after first turn

### DIFF
--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -35,6 +35,7 @@ from .media_filedata import (
     inject_cofacts_media_filedata,
 )
 from .instrumentation import LangfuseTracingPlugin, setup_instrumentation
+from .session_title import generate_session_title
 from .tools import (
     draft_factcheck_response,
     get_single_cofacts_article,
@@ -639,7 +640,7 @@ ai_writer = LlmAgent(
     before_model_callback=inject_article_attachment,
     after_tool_callback=after_tool,
     on_tool_error_callback=handle_writer_tool_error,
-    after_agent_callback=update_last_event_time,
+    after_agent_callback=[update_last_event_time, generate_session_title],
     instruction=f"""
     You are an AI Writer and orchestrator for the Cofacts fact-checking system. Today is {datetime.now().strftime("%Y-%m-%d")}.
 

--- a/adk/cofacts_ai/session_title.py
+++ b/adk/cofacts_ai/session_title.py
@@ -111,10 +111,31 @@ def _truncate_prompt_text(text: str) -> str:
     return text[:PROMPT_TEXT_LIMIT].rstrip()
 
 
+# Quote characters the model sometimes wraps the whole title in. Stripped only as a
+# matched pair, so a title that legitimately contains a quote (\u4ed6\u8aaa\u300c\u9019\u662f\u5047\u7684\u300d) keeps it.
+_QUOTE_PAIRS = {
+    '"': '"',
+    "'": "'",
+    "`": "`",
+    "\u201c": "\u201d",
+    "\u2018": "\u2019",
+    "\u300c": "\u300d",
+    "\u300e": "\u300f",
+}
+
+
+def _strip_wrapping_quotes(title: str) -> str:
+    while len(title) >= 2:
+        closing = _QUOTE_PAIRS.get(title[0])
+        if closing is None or not title.endswith(closing):
+            break
+        title = title[1:-1].strip()
+    return title
+
+
 def _normalize_title(title: str) -> str:
     title = " ".join(title.split()).strip()
-    title = title.strip("\"'`\u201c\u201d\u2018\u2019\u300c\u300d\u300e\u300f")
-    title = title.strip()
+    title = _strip_wrapping_quotes(title)
     if len(title) > MAX_TITLE_LENGTH:
         title = title[:MAX_TITLE_LENGTH].rstrip()
     return title

--- a/adk/cofacts_ai/session_title.py
+++ b/adk/cofacts_ai/session_title.py
@@ -1,0 +1,120 @@
+import asyncio
+import logging
+
+from google import genai
+from google.genai import types as genai_types
+
+logger = logging.getLogger(__name__)
+
+TITLE_STATE_KEY = "title"
+TITLE_MODEL = "gemini-3.1-flash-lite"
+MAX_TITLE_LENGTH = 60
+PROMPT_TEXT_LIMIT = 4000
+TITLE_TIMEOUT_SECONDS = 10
+
+# Reuse a single genai client across sessions instead of constructing one (and
+# re-resolving ADC) on every first turn. Lazily initialized so importing this
+# module needs no credentials.
+_client = None
+
+
+def _get_client():
+    global _client
+    if _client is None:
+        _client = genai.Client()
+    return _client
+
+
+async def generate_session_title(callback_context) -> None:
+    """Generates a session title after the first writer turn."""
+    if _count_user_events(callback_context.session.events) != 1:
+        return None
+
+    user_text = _content_text(callback_context.user_content)
+    result_text = _last_writer_text(callback_context.session.events)
+    if not user_text and not result_text:
+        return None
+
+    try:
+        raw_title = await asyncio.wait_for(
+            _generate_title(user_text, result_text),
+            timeout=TITLE_TIMEOUT_SECONDS,
+        )
+    except Exception:
+        logger.exception("Failed to generate session title")
+        return None
+
+    title = _normalize_title(raw_title)
+    if title:
+        callback_context.state[TITLE_STATE_KEY] = title
+    return None
+
+
+def _count_user_events(events) -> int:
+    return sum(1 for event in events if event.author == "user")
+
+
+def _last_writer_text(events) -> str:
+    for event in reversed(events):
+        if event.author != "writer":
+            continue
+        text = _content_text(event.content)
+        if text:
+            return text
+    return ""
+
+
+def _content_text(content) -> str:
+    if not content or not content.parts:
+        return ""
+    texts = []
+    for part in content.parts:
+        text = getattr(part, "text", None)
+        if isinstance(text, str) and not getattr(part, "thought", False):
+            texts.append(text)
+    return "".join(texts).strip()
+
+
+async def _generate_title(user_text: str, result_text: str) -> str:
+    response = await _get_client().aio.models.generate_content(
+        model=TITLE_MODEL,
+        contents=_build_prompt(user_text, result_text),
+        config=genai_types.GenerateContentConfig(
+            thinking_config=genai_types.ThinkingConfig(
+                thinking_level=genai_types.ThinkingLevel.MINIMAL
+            ),
+            max_output_tokens=128,
+        ),
+    )
+    return response.text or ""
+
+
+def _build_prompt(user_text: str, result_text: str) -> str:
+    prompt = (
+        "Return ONLY a concise, meaningful session title in the same language "
+        "as the content. Use Traditional Chinese when the content is "
+        "Traditional Chinese. Keep it under 60 characters. Do not include "
+        "quotes or explanations.\n\n"
+        f"User's first message:\n{_truncate_prompt_text(user_text)}"
+    )
+    if result_text:
+        prompt += (
+            "\n\nWriter's first result:\n"
+            f"{_truncate_prompt_text(result_text)}"
+        )
+    return prompt
+
+
+def _truncate_prompt_text(text: str) -> str:
+    if len(text) <= PROMPT_TEXT_LIMIT:
+        return text
+    return text[:PROMPT_TEXT_LIMIT].rstrip()
+
+
+def _normalize_title(title: str) -> str:
+    title = " ".join(title.split()).strip()
+    title = title.strip("\"'`\u201c\u201d\u2018\u2019\u300c\u300d\u300e\u300f")
+    title = title.strip()
+    if len(title) > MAX_TITLE_LENGTH:
+        title = title[:MAX_TITLE_LENGTH].rstrip()
+    return title

--- a/adk/cofacts_ai/session_title_test.py
+++ b/adk/cofacts_ai/session_title_test.py
@@ -2,7 +2,7 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
-from cofacts_ai.session_title import generate_session_title
+from cofacts_ai.session_title import _normalize_title, generate_session_title
 
 
 class GenerateSessionTitleTest(unittest.IsolatedAsyncioTestCase):
@@ -80,6 +80,24 @@ class GenerateSessionTitleTest(unittest.IsolatedAsyncioTestCase):
             await generate_session_title(context)
 
         self.assertEqual(context.state["title"], "請查證")
+
+
+class NormalizeTitleTest(unittest.TestCase):
+    def test_strips_a_matched_wrapping_quote_pair(self):
+        self.assertEqual(_normalize_title(' "台電停電查證"\n '), "台電停電查證")
+        self.assertEqual(_normalize_title("「台電停電查證」"), "台電停電查證")
+
+    def test_keeps_quotes_that_belong_to_the_title(self):
+        # An unmatched edge quote is part of the content, not a wrapper: it must survive.
+        self.assertEqual(_normalize_title("他說「這是假的」"), "他說「這是假的」")
+        self.assertEqual(
+            _normalize_title("台電停電傳言：「假的」"), "台電停電傳言：「假的」"
+        )
+        self.assertEqual(_normalize_title("「台電停電」是假的"), "「台電停電」是假的")
+
+    def test_collapses_whitespace_and_truncates(self):
+        self.assertEqual(_normalize_title("  台電   停電  "), "台電 停電")
+        self.assertEqual(len(_normalize_title("字" * 80)), 60)
 
 
 def _context(events, user_text="", title="placeholder"):

--- a/adk/cofacts_ai/session_title_test.py
+++ b/adk/cofacts_ai/session_title_test.py
@@ -1,0 +1,112 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from cofacts_ai.session_title import generate_session_title
+
+
+class GenerateSessionTitleTest(unittest.IsolatedAsyncioTestCase):
+    async def test_first_turn_sets_normalized_title(self):
+        generate_content = AsyncMock(
+            return_value=SimpleNamespace(text=' "台電停電查證"\n ')
+        )
+        client = _client(generate_content)
+        context = _context(
+            [
+                _event("user", "請查證台電停電傳言"),
+                _event("writer", "這則訊息需要比對台電公告。"),
+            ],
+            user_text="請查證台電停電傳言",
+            title="請查證台電停電傳言",
+        )
+
+        with patch("cofacts_ai.session_title._get_client", return_value=client):
+            await generate_session_title(context)
+
+        self.assertEqual(context.state["title"], "台電停電查證")
+        generate_content.assert_awaited_once()
+
+    async def test_second_turn_does_not_call_llm(self):
+        context = _context(
+            [
+                _event("user", "第一則訊息"),
+                _event("writer", "第一回覆"),
+                _event("user", "第二則訊息"),
+            ],
+            user_text="第二則訊息",
+            title="使用者改過的標題",
+        )
+
+        with patch("cofacts_ai.session_title._get_client") as get_client:
+            await generate_session_title(context)
+
+        self.assertEqual(context.state["title"], "使用者改過的標題")
+        get_client.assert_not_called()
+
+    async def test_llm_error_leaves_title_unchanged(self):
+        generate_content = AsyncMock(side_effect=RuntimeError("boom"))
+        client = _client(generate_content)
+        context = _context(
+            [
+                _event("user", "請查證"),
+                _event("writer", "查證結果"),
+            ],
+            user_text="請查證",
+            title="請查證",
+        )
+
+        with (
+            patch("cofacts_ai.session_title._get_client", return_value=client),
+            patch("cofacts_ai.session_title.logger.exception") as log_error,
+        ):
+            await generate_session_title(context)
+
+        self.assertEqual(context.state["title"], "請查證")
+        log_error.assert_called_once()
+
+    async def test_whitespace_title_is_not_written(self):
+        generate_content = AsyncMock(return_value=SimpleNamespace(text="\n  \t"))
+        client = _client(generate_content)
+        context = _context(
+            [
+                _event("user", "請查證"),
+                _event("writer", "查證結果"),
+            ],
+            user_text="請查證",
+            title="請查證",
+        )
+
+        with patch("cofacts_ai.session_title._get_client", return_value=client):
+            await generate_session_title(context)
+
+        self.assertEqual(context.state["title"], "請查證")
+
+
+def _context(events, user_text="", title="placeholder"):
+    return SimpleNamespace(
+        session=SimpleNamespace(events=events),
+        user_content=_content(user_text),
+        state={"title": title},
+    )
+
+
+def _event(author, text):
+    return SimpleNamespace(author=author, content=_content(text))
+
+
+def _content(text):
+    return SimpleNamespace(
+        parts=[SimpleNamespace(text=text, thought=False)] if text else []
+    )
+
+
+def _client(generate_content):
+    return SimpleNamespace(
+        aio=SimpleNamespace(
+            models=SimpleNamespace(generate_content=generate_content),
+        )
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,7 +1,9 @@
 import { Link, useParams } from '@tanstack/react-router'
 import { useState } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import type { ChatSessionState } from '@/lib/chatCache'
 import type { SessionListItem } from '@/lib/chatSessions.functions'
+import { chatCacheKey } from '@/lib/chatCache'
 import { useSessions } from '@/hooks/useSessions'
 import { updateSessionTitle } from '@/lib/chatSessions.functions'
 import { handleAuthExpired, isAuthExpiredError } from '@/lib/authExpired'
@@ -23,6 +25,17 @@ function SessionItem({ session, isActive, onClose }: SessionItemProps) {
   const [editTitle, setEditTitle] = useState('')
   const { title, lastEventTime, lastOpenedAt, lastUpdateTime } = session
 
+  // The session title is written to ADK state after the first turn finishes. A rename
+  // issued while that write is still in flight would be lost to the last-write-wins
+  // state merge, so the rename affordance stays hidden until the stream ends.
+  // Read-only subscription: `enabled: false` means the sidebar never fetches, it only
+  // observes the chat cache that useChat maintains.
+  const { data: chatState } = useQuery<ChatSessionState>({
+    queryKey: chatCacheKey(session.id),
+    enabled: false,
+  })
+  const isStreaming = chatState?.isStreaming ?? false
+
   const hasNew =
     !isActive &&
     lastEventTime !== undefined &&
@@ -39,6 +52,7 @@ function SessionItem({ session, isActive, onClose }: SessionItemProps) {
   const handleStartEdit = (e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
+    if (isStreaming) return
     setIsEditing(true)
     setEditTitle(title)
   }
@@ -126,7 +140,7 @@ function SessionItem({ session, isActive, onClose }: SessionItemProps) {
         </Link>
       )}
 
-      {!isEditing && (
+      {!isEditing && !isStreaming && (
         <button
           onClick={handleStartEdit}
           className="absolute right-2 top-3 p-1 opacity-0 group-hover:opacity-100 text-gray-400 hover:text-primary transition-opacity"


### PR DESCRIPTION
Closes #87.

At the end of a session's first turn, an LLM generates a concise title from the
user's first message and the writer's first result, replacing the placeholder
title (the raw message truncated to 40 chars) that the frontend sets at session
creation.

## Design
- New after_agent_callback `generate_session_title` in `adk/cofacts_ai/session_title.py`,
  registered alongside `update_last_event_time` on `ai_writer`.
- Runs on the first turn only (exactly one user event), so it never regenerates on
  later turns and never overwrites a title the user edited in the sidebar.
- Uses the cheap tier `gemini-3.1-flash-lite` via ADC/Vertex, thinking level MINIMAL,
  max_output_tokens 128, with a 10s timeout. Any failure is caught and the placeholder
  title is kept, so a title error never breaks the agent turn.
- Reuses a single lazily-initialized module-scoped genai client rather than constructing
  one per turn, mirroring the ADC-caching pattern adopted in #99.
- Stores the normalized title in session state under `title` — the key the frontend
  already reads (`listSessions`) and renders in the sidebar, so no frontend change is needed.

## Verification
Verified offline (mocking the genai client) across: first-turn title generation and
normalization, second-turn no-op (LLM not called), LLM failure leaving the title
unchanged, and a whitespace-only result not being written. Deterministic on repeat.
- `python -m unittest cofacts_ai.session_title_test` -> 4 passed, 0 failed
- `python -m py_compile` on changed files -> clean

The live integration test (an actual title generated end-to-end on Vertex) is still
pending, so I am keeping this as a Draft for now.