### PR TITLE
ci: add frontend lint/format/typecheck job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,3 +30,32 @@ jobs:
 
       - name: Run pytest
         run: uv run pytest -v
+
+  test-frontend:
+    name: Test frontend (lint, format, typecheck)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint (ESLint)
+        run: pnpm run lint
+
+      - name: Format check (Prettier)
+        run: pnpm exec prettier --check .
+
+      - name: Type check (TypeScript)
+        run: pnpm exec tsc --noEmit


### PR DESCRIPTION
## Summary
- Adds a `test-frontend` job to `.github/workflows/ci.yaml` that runs ESLint, `prettier --check`, and `tsc --noEmit`, mirroring the checks proposed in #23.
- Config-only change, kept separate to make the workflow diff easy to review.

**This PR's CI is expected to fail** — `eslint` isn't currently a direct devDependency (`pnpm run lint` → `command not found`) and ~37 files aren't Prettier-formatted yet. A stacked follow-up PR cleans those up so CI goes green.

## Test plan
- [ ] Confirm the `test-frontend` job appears and fails as expected (lint + format errors)
- [ ] Merge after/alongside the follow-up cleanup PR