### PR TITLE
fix: satisfy Vertex AI constraints when injecting YouTube FileData

### DIFF
--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -191,9 +191,16 @@ def inject_youtube_filedata(
 
     Vertex AI supports only one YouTube video URL per request, so this
     appends a single FileData part for the first YouTube URL of the latest
-    user message that has one (the most recent message is the current task).
+    user message that has one. Latest wins because the most recent message
+    is the current task: if this callback ever runs on an agent with real
+    multi-turn history, picking the earliest URL would pin every request to
+    the first video ever mentioned, even after the user moves on to another.
+    (Today each AgentTool call starts a fresh single-message session, so
+    latest vs. earliest makes no difference yet.)
     When other URLs are present, a [SYSTEM] text part lists them so the model
     knows they are not loaded and can examine them in separate requests.
+    All contents are still scanned even though only one video is injected —
+    the notice must enumerate every URL that was NOT loaded.
     The original URLs are kept intact so url_context still fetches their
     title/description metadata.
 

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -189,15 +189,24 @@ def inject_youtube_filedata(
 ) -> None:
     """Before-model callback for ai_investigator and ai_verifier.
 
-    For each user message that contains YouTube URLs, appends FileData parts
-    into the same parts array so Gemini can watch the videos inline.
+    Vertex AI supports only one YouTube video URL per request, so this
+    appends a single FileData part for the first YouTube URL of the latest
+    user message that has one (the most recent message is the current task).
+    When other URLs are present, a [SYSTEM] text part lists them so the model
+    knows they are not loaded and can examine them in separate requests.
     The original URLs are kept intact so url_context still fetches their
     title/description metadata.
 
-    Ref: https://ai.google.dev/gemini-api/docs/video-understanding#youtube
+    Refs:
+    - https://ai.google.dev/gemini-api/docs/video-understanding#youtube
+    - https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/video-understanding
+      (Vertex AI requires mimeType alongside fileUri, and supports only one
+      YouTube URL per request.)
     """
     try:
-        seen = set()
+        seen = {}  # dict as ordered set, so the notice lists URLs in order
+        chosen_content = None
+        chosen_url = None
         for content in llm_request.contents:
             if content.role != "user" or not content.parts:
                 continue
@@ -205,12 +214,38 @@ def inject_youtube_filedata(
             for part in content.parts:
                 if part.text:
                     youtube_urls.extend(_YOUTUBE_URL_RE.findall(part.text))
+            if not youtube_urls:
+                continue
+            # First URL of the latest user message with a YouTube URL wins.
+            chosen_content = content
+            chosen_url = youtube_urls[0]
             for url in youtube_urls:
-                if url not in seen:
-                    seen.add(url)
-                    content.parts.append(
-                        genai_types.Part(file_data=genai_types.FileData(file_uri=url))
+                seen[url] = True
+        if chosen_content is None:
+            return None
+        chosen_content.parts.append(
+            genai_types.Part(
+                file_data=genai_types.FileData(
+                    # Vertex AI rejects fileData with an empty mimeType.
+                    # video/webm follows the official notebook:
+                    # https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/use-cases/video-analysis/youtube_video_analysis.ipynb
+                    file_uri=chosen_url,
+                    mime_type="video/webm",
+                )
+            )
+        )
+        skipped = [url for url in seen if url != chosen_url]
+        if skipped:
+            chosen_content.parts.append(
+                genai_types.Part(
+                    text=(
+                        "[SYSTEM] Gemini can watch only one YouTube video per "
+                        f"request. Watching now: {chosen_url}. NOT loaded: "
+                        f"{', '.join(skipped)}. To examine another video, make "
+                        "a separate request containing only that URL."
                     )
+                )
+            )
     except Exception:
         logger.exception("inject_youtube_filedata failed; skipping YouTube injection")
     return None
@@ -696,7 +731,7 @@ ai_writer = LlmAgent(
        - **If the message centers on a video/audio or a linked URL**: you cannot watch a video, listen to audio, or read a page yourself — only `verifier` can (it watches/listens via FileData and reads page metadata such as upload date). Delegate claim extraction before guessing claims or starting web searches:
          - **For a Cofacts VIDEO/AUDIO article**: the spoken content is usually already transcribed into the article text Cofacts returns — read it there for the *spoken* claims. Even when that transcript looks complete, a VIDEO/AUDIO article still needs **at least one** `verifier` pass that actually watches/listens to the media, because the transcript only covers the audio: use it to (a) enumerate the *visual* layer (on-screen text, logos, who/where) that the transcript misses, and (b) confirm the transcript matches what is actually said. Ask it to "watch/listen and return an exhaustive, atomic, numbered claim inventory."
            - **Pass the article's `attachmentUrl` value to `verifier`** — `get_single_cofacts_article` returns it as a `gs://...` URI that `verifier` can load the media directly from, so forward it as-is.
-         - **For a linked external URL or YouTube video** (claims NOT in the article text): your FIRST action is to call `verifier` with the URL and ask it to "watch the video / read the page and return an exhaustive, atomic, numbered claim inventory."
+         - **For a linked external URL or YouTube video** (claims NOT in the article text): your FIRST action is to call `verifier` with the URL and ask it to "watch the video / read the page and return an exhaustive, atomic, numbered claim inventory." Include only ONE YouTube link per `verifier`/`investigator` call — it can only watch one video per request, so for multiple videos make a separate call for each.
          - You can follow up and ask `verifier` to re-watch one specific aspect (a timestamp, a face, a piece of on-screen text) without re-running the whole inventory.
        - **If the message centers on an IMAGE**: you can see the image yourself (it is injected as a FileData part), but from looking at it alone you cannot tell whether it has been repurposed, taken out of context, or AI-generated. When the claim depends on the image being authentic or used in its original context, call `search_image_web` with the article's `attachmentUrl`. `get_single_cofacts_article` returns it as a `gs://...` URI, so forward it as-is. Use `bestGuessLabels` and `webEntities` to identify what the image actually shows, and feed `pagesWithMatchingImages` (favoring earlier-dated or differently-captioned pages) to `investigator`/`verifier` to confirm the original source and date. `search_image_web` results can be noisy or incomplete, so treat them as a weak lead, never as ground truth: do not cite a matching page directly, and always confirm any lead through `investigator`/`verifier` before relying on it. `search_image_web` is for IMAGE articles only; VIDEO/AUDIO go to `verifier`.
        - Identify factual statements vs. opinions in the message

--- a/adk/cofacts_ai/tests/test_youtube_filedata.py
+++ b/adk/cofacts_ai/tests/test_youtube_filedata.py
@@ -1,0 +1,118 @@
+"""Unit tests for `inject_youtube_filedata`.
+
+The before-model callback appends a FileData part so Gemini can watch a
+YouTube video found in user messages. Two Vertex AI constraints drive the
+regression tests here: fileData with an empty mimeType is rejected
+(400 INVALID_ARGUMENT), and only one YouTube URL is supported per request —
+so at most one FileData is injected and a [SYSTEM] notice lists any URLs
+that were not loaded.
+"""
+
+from typing import cast
+
+from google.adk.agents.callback_context import CallbackContext
+from google.adk.models.llm_request import LlmRequest
+from google.genai import types as genai_types
+
+from cofacts_ai.agent import inject_youtube_filedata
+
+
+def make_request(*contents: genai_types.Content) -> LlmRequest:
+    return LlmRequest(contents=list(contents))
+
+
+def user_text(text: str) -> genai_types.Content:
+    return genai_types.Content(role="user", parts=[genai_types.Part(text=text)])
+
+
+def file_data_parts(content: genai_types.Content) -> list[genai_types.FileData]:
+    return [part.file_data for part in content.parts or [] if part.file_data]
+
+
+def system_notices(content: genai_types.Content) -> list[str]:
+    return [
+        part.text
+        for part in content.parts or []
+        if part.text and part.text.startswith("[SYSTEM]")
+    ]
+
+
+class TestInjectYoutubeFiledata:
+    def test_shorts_url_appends_filedata_with_mime_type(self):
+        url = "https://youtube.com/shorts/uLOZXNhN4sY?si=lWk1QGHkASEvVXlo"
+        request = make_request(user_text(f"請查核 {url} 這則影片"))
+
+        inject_youtube_filedata(cast(CallbackContext, None), request)
+
+        [file_data] = file_data_parts(request.contents[0])
+        assert file_data.file_uri == url
+        assert file_data.mime_type == "video/webm"
+
+    def test_single_url_adds_no_system_notice(self):
+        request = make_request(user_text("https://youtu.be/abc123"))
+
+        inject_youtube_filedata(cast(CallbackContext, None), request)
+
+        assert len(file_data_parts(request.contents[0])) == 1
+        assert system_notices(request.contents[0]) == []
+
+    def test_multiple_urls_in_one_message_injects_first_and_notes_rest(self):
+        request = make_request(
+            user_text(
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ "
+                "and https://youtu.be/abc123"
+            )
+        )
+
+        inject_youtube_filedata(cast(CallbackContext, None), request)
+
+        [file_data] = file_data_parts(request.contents[0])
+        assert file_data.file_uri == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        [notice] = system_notices(request.contents[0])
+        assert "https://youtu.be/abc123" in notice
+
+    def test_urls_across_messages_injects_latest_and_notes_earlier(self):
+        request = make_request(
+            user_text("https://youtu.be/earlier"),
+            user_text("https://youtu.be/latest"),
+        )
+
+        inject_youtube_filedata(cast(CallbackContext, None), request)
+
+        assert file_data_parts(request.contents[0]) == []
+        [file_data] = file_data_parts(request.contents[1])
+        assert file_data.file_uri == "https://youtu.be/latest"
+        [notice] = system_notices(request.contents[1])
+        assert "https://youtu.be/earlier" in notice
+        assert "https://youtu.be/latest" in notice
+
+    def test_duplicate_urls_injected_once_on_latest_message(self):
+        url = "https://youtube.com/shorts/uLOZXNhN4sY"
+        request = make_request(user_text(url), user_text(url))
+
+        inject_youtube_filedata(cast(CallbackContext, None), request)
+
+        assert file_data_parts(request.contents[0]) == []
+        [file_data] = file_data_parts(request.contents[1])
+        assert file_data.file_uri == url
+        assert system_notices(request.contents[1]) == []
+
+    def test_model_role_content_is_ignored(self):
+        request = make_request(
+            genai_types.Content(
+                role="model",
+                parts=[genai_types.Part(text="https://youtu.be/abc123")],
+            )
+        )
+
+        inject_youtube_filedata(cast(CallbackContext, None), request)
+
+        assert file_data_parts(request.contents[0]) == []
+
+    def test_text_without_youtube_url_is_untouched(self):
+        request = make_request(user_text("https://cofacts.tw/article/1xspprmokh0z6"))
+
+        inject_youtube_filedata(cast(CallbackContext, None), request)
+
+        assert file_data_parts(request.contents[0]) == []
+        assert len(request.contents[0].parts) == 1


### PR DESCRIPTION
## Problem

In [this session](https://langfuse.cofacts.tw/project/cmm0emerr0001qi07eugd0760/sessions/838e21e3-93d4-4da2-ad1e-648e1fcb2304), the agent claimed it could not watch a YouTube Short even though `inject_youtube_filedata` correctly detected the URL and injected a FileData part.

The Langfuse trace shows every investigator/verifier call carrying the injected part failed with:

> `400 INVALID_ARGUMENT: Unable to submit request because it has an empty mimeType parameter in fileData.`

The callback followed the Gemini Developer API docs, where `mime_type` is optional for YouTube URLs — but we run on Vertex AI, whose [video-understanding docs](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/video-understanding) (REST tab, `FILE_URI` parameter) state:

> Only one YouTube video URL is supported per request. When specifying a `fileURI`, you must also specify the media type (`mimeType`) of the file.

## Changes

- Set `mime_type="video/webm"` on the injected FileData, following the [official YouTube video analysis notebook](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/use-cases/video-analysis/youtube_video_analysis.ipynb)
- Inject **at most one** FileData per request (first URL of the latest user message containing one). Other URLs get a `[SYSTEM]` text notice so the model knows they are not loaded and can examine them in separate requests, instead of hallucinating or claiming blindness
- Writer instruction: delegate only one YouTube link per `verifier`/`investigator` call
- Add unit tests for the callback (`test_youtube_filedata.py`, 7 cases)

## Test

- `uv run pytest cofacts_ai/tests/ -q` → 25 passed
- REPL spot-check: a request with two YouTube URLs yields exactly one `file_data` part (`video/webm`) plus the `[SYSTEM]` notice listing the skipped URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)