### PR TITLE
Upgrade writer & investigator to gemini-3.5-flash

### DIFF
--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -262,14 +262,11 @@ def inject_youtube_filedata(
 # AI Web Searcher - Google Search snippet reporter
 ai_investigator = LlmAgent(
     name="investigator",
-    # Reference: Gemini CLI is also using gemini-3-flash-preview for web-search
-    # https://github.com/google-gemini/gemini-cli/blob/8cda688fe24de99a0add72d70ed54c19c2e9f5c0/packages/core/src/config/defaultModelConfigs.ts#L185-L192
-    #
-    model="gemini-3-flash-preview",
+    model="gemini-3.5-flash",
     description="A research assistant you can delegate fact-checking tasks to. Describe what you want to know or investigate; it will search the web, read results, and report back with detailed findings. Returns {content, sources} — sources lists reliable {title, url} pairs.",
     generate_content_config=genai_types.GenerateContentConfig(
         thinking_config=genai_types.ThinkingConfig(
-            thinking_level=genai_types.ThinkingLevel.MEDIUM
+            thinking_level=genai_types.ThinkingLevel.HIGH
         )
     ),
     before_model_callback=inject_youtube_filedata,
@@ -682,7 +679,7 @@ def handle_writer_tool_error(
 # This architecture respects ADK constraints while maintaining full functionality.
 ai_writer = LlmAgent(
     name="writer",
-    model="gemini-3-flash-preview",
+    model="gemini-3.5-flash",
     description="AI agent that orchestrates fact-checking process and composes final fact-check replies for Cofacts.",
     generate_content_config=genai_types.GenerateContentConfig(
         thinking_config=genai_types.ThinkingConfig(

--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -125,7 +125,11 @@ async def append_grounding_sources(
     ]
 
     # ── B: Build content from all text parts ─────────────────────────────────
-    content = "".join(p.text or "" for p in llm_response.content.parts)
+    # Skip thought-summary parts (include_thoughts=True) so the writer's tool
+    # result contains only the report, while thoughts remain in Langfuse traces.
+    content = "".join(
+        p.text or "" for p in llm_response.content.parts if not p.thought
+    )
 
     # ── Write back as JSON so writer's after_tool_callback gets structured output
     response_dict: dict = {"content": content, "sources": sources_list}
@@ -266,7 +270,7 @@ ai_investigator = LlmAgent(
     description="A research assistant you can delegate fact-checking tasks to. Describe what you want to know or investigate; it will search the web, read results, and report back with detailed findings. Returns {content, sources} — sources lists reliable {title, url} pairs.",
     generate_content_config=genai_types.GenerateContentConfig(
         thinking_config=genai_types.ThinkingConfig(
-            thinking_level=genai_types.ThinkingLevel.HIGH
+            include_thoughts=True, thinking_level=genai_types.ThinkingLevel.HIGH
         )
     ),
     before_model_callback=inject_youtube_filedata,

--- a/adk/cofacts_ai/tests/test_writer_callbacks.py
+++ b/adk/cofacts_ai/tests/test_writer_callbacks.py
@@ -264,3 +264,50 @@ class TestHandleWriterToolError:
                 "Please note this failure and continue with available information."
             ),
         }
+
+
+class TestAppendGroundingSources:
+    """append_grounding_sources builds {content, sources} from the raw
+    investigator response. `content` must exclude thought-summary parts
+    (include_thoughts=True) so the writer's tool result contains only the
+    report, while thoughts remain visible in Langfuse traces."""
+
+    async def test_thought_parts_excluded_from_content(self, monkeypatch):
+        from cofacts_ai import agent as agent_module
+        from google.adk.models.llm_response import LlmResponse
+        from google.genai import types as genai_types
+
+        async def fake_resolve(url):
+            return url
+
+        monkeypatch.setattr(agent_module, "resolve_vertex_redirect", fake_resolve)
+
+        llm_response = LlmResponse(
+            content=genai_types.Content(
+                role="model",
+                parts=[
+                    genai_types.Part(text="**Planning the search** ...", thought=True),
+                    genai_types.Part(text="實際調查報告內容"),
+                ],
+            ),
+            grounding_metadata=genai_types.GroundingMetadata(
+                grounding_chunks=[
+                    genai_types.GroundingChunk(
+                        web=genai_types.GroundingChunkWeb(
+                            uri="https://example.com/a", title="Example"
+                        )
+                    )
+                ],
+            ),
+        )
+
+        result = await agent_module.append_grounding_sources(
+            callback_context=cast(CallbackContext, AsyncMock()),
+            llm_response=llm_response,
+        )
+
+        payload = json.loads(result.content.parts[0].text)
+        assert payload["content"] == "實際調查報告內容"
+        assert payload["sources"] == [
+            {"title": "Example", "url": "https://example.com/a"}
+        ]


### PR DESCRIPTION
## Why

Langfuse trace analysis of three fact-checking sessions (2026-07-11) attributed the worst failures to the **writer** on `gemini-3-flash-preview`:

- [cmoney session 1](https://langfuse.cofacts.tw/project/cmm0emerr0001qi07eugd0760/sessions/54d55951-e3d5-417b-afce-766f99bca41d) — fabricated URLs (turns 15:41, 15:43)
- [cmoney session 2](https://langfuse.cofacts.tw/project/cmm0emerr0001qi07eugd0760/sessions/eff1ce5b-3ff6-484b-9414-7a0f486c05c5) — investigator hallucination (turn 15:46), empty response (turn 15:52), 14 turns total
- [中聯油品 session](https://langfuse.cofacts.tw/project/cmm0emerr0001qi07eugd0760/sessions/33328110-25d9-4758-94be-62a23f5d69ca) — proofreaders addressed in prose but never called (turns 17:34, 17:38)

The failure modes:

- **Addressed proofreaders in prose without calling them** — two turns ended with "`proofreader_kmt`、`proofreader_dpp`、`proofreader_tpp`、`proofreader_minor_parties` 請提供意見。" with `finish_reason=STOP` and zero function calls; the user had to say「請 proofreader 說話」to trigger the real calls.
- **Fabricated URLs** — invented `https://www.cmoney.tw/app/ItemContent.aspx?id=12345`「範例網址」in two turns, despite the "NEVER guess or invent a URL" rule that has been in the writer instruction since May.
- **Empty response** — one turn burned 21k prompt tokens and returned an empty text part (null output), forcing the user to re-send.

The **investigator** also over-stated `google_search` grounding into concrete claims (e.g. a nonexistent official Facebook/Line promotion by CMoney), and was the only agent still at thinking `MEDIUM`.

The writer already ran at thinking `HIGH`, so the lever is model tier, not thinking effort. `gemini-3.5-flash` leads `gemini-3.1-pro` on tool-call reliability and agentic benchmarks (MCP Atlas 83.6 vs 78.2, Terminal-Bench 2.1 76.2 vs 70.3) at ~2× output speed — exactly the failure quadrant above.

## What

- writer: `gemini-3-flash-preview` → `gemini-3.5-flash`
- investigator: `gemini-3-flash-preview` → `gemini-3.5-flash`, thinking `MEDIUM` → `HIGH`; drop the stale "Gemini CLI also uses 3-flash-preview" reference comment
- investigator: `include_thoughts=True` so its reasoning appears in Langfuse traces; `append_grounding_sources` now skips `thought` parts so summaries never leak into the `{content}` the writer consumes (from review feedback)
- verifier stays on `gemini-3-flash-preview` until `url_context` support on 3.5-flash is confirmed; proofreaders stay on `gemini-3.1-flash-lite`

Out of scope by design: writer empty-response guard (re-evaluate after the upgrade), anti-crawler fallback (separate url-resolver work).

## Verification

- `uv run pytest`: 19 passed (includes a new test locking the thought-part filtering in `append_grounding_sources`)
- Live smoke test on Vertex AI: `gemini-3.5-flash` reachable in this project; `google_search` built-in tool + `thinking_level=HIGH` works and returns grounding chunks (required by `append_grounding_sources`)
- Follow-up: re-run the three original messages via `adk web` and check the new Langfuse traces — every proofreader mention must have a matching function call, all cited URLs must come from `sources[]`, no empty-response turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)
