### PR TITLE
feat(instrumentation): extract plain text for Langfuse trace input/output

### DIFF
--- a/adk/cofacts_ai/instrumentation.py
+++ b/adk/cofacts_ai/instrumentation.py
@@ -149,19 +149,22 @@ def _move_processor_first(provider: SDKTracerProvider, processor: SpanProcessor)
     public ordering API; on any surprise we leave the order unchanged, which
     degrades to that occasional race, not to an error.
     """
-    multi = getattr(provider, "_active_span_processor", None)
-    processors = getattr(multi, "_span_processors", None)
-    if (
-        multi is None
-        or not isinstance(processors, tuple)
-        or processor not in processors
-    ):
-        logger.warning("Could not reorder span processors; rewrite runs last.")
-        return
-    multi._span_processors = (
-        processor,
-        *(p for p in processors if p is not processor),
-    )
+    try:
+        multi = getattr(provider, "_active_span_processor", None)
+        processors = getattr(multi, "_span_processors", None)
+        if (
+            multi is None
+            or not isinstance(processors, tuple)
+            or processor not in processors
+        ):
+            logger.warning("Could not reorder span processors; rewrite runs last.")
+            return
+        multi._span_processors = (
+            processor,
+            *(p for p in processors if p is not processor),
+        )
+    except Exception:
+        logger.exception("Could not reorder span processors; rewrite runs last.")
 
 
 def setup_instrumentation():

--- a/adk/cofacts_ai/instrumentation.py
+++ b/adk/cofacts_ai/instrumentation.py
@@ -1,6 +1,7 @@
+import json
 import logging
 import os
-from typing import cast
+from typing import Optional, cast
 
 from google.adk.agents.invocation_context import InvocationContext
 from google.adk.plugins.base_plugin import BasePlugin
@@ -20,6 +21,15 @@ _SESSION_ID_ATTR = SpanAttributes.SESSION_ID
 _LANGFUSE_SESSION_ID_ATTR = "langfuse.session.id"
 # Key used in event.custom_metadata to link events back to their Langfuse trace
 _LANGFUSE_TRACE_ID_KEY = "langfuse_trace_id"
+
+# openinference semconv: "input.value" / "output.value" and their mime types.
+# Langfuse shows the root span's input/output as the trace's input/output in
+# session view.
+_INPUT_VALUE_ATTR = SpanAttributes.INPUT_VALUE
+_INPUT_MIME_ATTR = SpanAttributes.INPUT_MIME_TYPE
+_OUTPUT_VALUE_ATTR = SpanAttributes.OUTPUT_VALUE
+_OUTPUT_MIME_ATTR = SpanAttributes.OUTPUT_MIME_TYPE
+_TEXT_MIME_TYPE = "text/plain"
 
 
 class RootSessionSpanProcessor(SpanProcessor):
@@ -52,6 +62,76 @@ class RootSessionSpanProcessor(SpanProcessor):
             span.set_attribute(_LANGFUSE_SESSION_ID_ATTR, session)
 
 
+def _parts_text(data: dict) -> Optional[str]:
+    """
+    Extracts joined text from an ADK message dict ({new_message|content}.parts).
+
+    Returns None when the dict has no recognizable parts or no text parts, so
+    callers keep the original attribute (e.g. tool-call payloads, image-only
+    messages). Thought parts are skipped: the writer runs with
+    include_thoughts=True, and thoughts are internal reasoning, not the
+    reply text.
+    """
+    content = data.get("new_message") or data.get("content")
+    if not isinstance(content, dict):
+        return None
+    parts = content.get("parts")
+    if not isinstance(parts, list):
+        return None
+    texts = [
+        text
+        for part in parts
+        if isinstance(part, dict)
+        and not part.get("thought")
+        and isinstance(text := part.get("text"), str)
+        and text
+    ]
+    if not texts:
+        return None
+    return "\n".join(texts)
+
+
+class TextExtractionSpanProcessor(SpanProcessor):
+    """
+    Rewrites input.value/output.value from serialized JSON to plain text so
+    traces are browsable in Langfuse's session view (#14).
+
+    GoogleADKInstrumentor stamps input.value with the serialized run_async
+    arguments and output.value with the final Event JSON; Langfuse then shows
+    raw JSON as the trace input/output. At on_end we parse those payloads and
+    replace them with the joined text of new_message.parts/content.parts.
+
+    on_end receives a ReadableSpan snapshot (no set_attribute), so we update
+    the underlying attribute mapping directly. Only existing keys are ever
+    replaced, never inserted or removed, and payloads without extractable
+    text are left untouched.
+    """
+
+    def on_end(self, span) -> None:
+        attributes = getattr(span, "_attributes", None)
+        if not attributes:
+            return
+        for value_attr, mime_attr in (
+            (_INPUT_VALUE_ATTR, _INPUT_MIME_ATTR),
+            (_OUTPUT_VALUE_ATTR, _OUTPUT_MIME_ATTR),
+        ):
+            raw = attributes.get(value_attr)
+            if not isinstance(raw, str):
+                continue
+            try:
+                data = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(data, dict):
+                continue
+            text = _parts_text(data)
+            if text is None:
+                continue
+            attributes[value_attr] = text
+            if mime_attr in attributes:
+                attributes[mime_attr] = _TEXT_MIME_TYPE
+
+
 def setup_instrumentation():
     """
     Sets up Langfuse instrumentation for Google ADK.
@@ -64,9 +144,9 @@ def setup_instrumentation():
 
     if langfuse.auth_check():
         GoogleADKInstrumentor().instrument()
-        cast(SDKTracerProvider, otel_trace.get_tracer_provider()).add_span_processor(
-            RootSessionSpanProcessor()
-        )
+        provider = cast(SDKTracerProvider, otel_trace.get_tracer_provider())
+        provider.add_span_processor(RootSessionSpanProcessor())
+        provider.add_span_processor(TextExtractionSpanProcessor())
         logger.info("Langfuse instrumentation initialized.")
     else:
         logger.warning("Langfuse authentication failed. Skipping instrumentation.")

--- a/adk/cofacts_ai/instrumentation.py
+++ b/adk/cofacts_ai/instrumentation.py
@@ -108,28 +108,34 @@ class TextExtractionSpanProcessor(SpanProcessor):
     """
 
     def on_end(self, span) -> None:
-        attributes = getattr(span, "_attributes", None)
-        if not attributes:
-            return
-        for value_attr, mime_attr in (
-            (_INPUT_VALUE_ATTR, _INPUT_MIME_ATTR),
-            (_OUTPUT_VALUE_ATTR, _OUTPUT_MIME_ATTR),
-        ):
-            raw = attributes.get(value_attr)
-            if not isinstance(raw, str):
-                continue
-            try:
-                data = json.loads(raw)
-            except json.JSONDecodeError:
-                continue
-            if not isinstance(data, dict):
-                continue
-            text = _parts_text(data)
-            if text is None:
-                continue
-            attributes[value_attr] = text
-            if mime_attr in attributes:
-                attributes[mime_attr] = _TEXT_MIME_TYPE
+        # Never let a rewrite failure break span end: the mapping is private
+        # SDK API, and OTel does not catch processor exceptions. A raise here
+        # would fail every span in the application.
+        try:
+            attributes = getattr(span, "_attributes", None)
+            if not attributes:
+                return
+            for value_attr, mime_attr in (
+                (_INPUT_VALUE_ATTR, _INPUT_MIME_ATTR),
+                (_OUTPUT_VALUE_ATTR, _OUTPUT_MIME_ATTR),
+            ):
+                raw = attributes.get(value_attr)
+                if not isinstance(raw, str):
+                    continue
+                try:
+                    data = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(data, dict):
+                    continue
+                text = _parts_text(data)
+                if text is None:
+                    continue
+                attributes[value_attr] = text
+                if mime_attr in attributes:
+                    attributes[mime_attr] = _TEXT_MIME_TYPE
+        except Exception:
+            logger.exception("Failed to rewrite span input/output text")
 
 
 def setup_instrumentation():

--- a/adk/cofacts_ai/instrumentation.py
+++ b/adk/cofacts_ai/instrumentation.py
@@ -138,6 +138,32 @@ class TextExtractionSpanProcessor(SpanProcessor):
             logger.exception("Failed to rewrite span input/output text")
 
 
+def _move_processor_first(provider: SDKTracerProvider, processor: SpanProcessor):
+    """
+    Moves `processor` ahead of previously registered span processors.
+
+    Langfuse's BatchSpanProcessor is registered inside get_client(), before we
+    can add ours, and processors run in registration order. Its on_end enqueues
+    the span for asynchronous export, so the rewrite must run first or a batch
+    flush can race it and export the raw JSON. The multi-processor has no
+    public ordering API; on any surprise we leave the order unchanged, which
+    degrades to that occasional race, not to an error.
+    """
+    multi = getattr(provider, "_active_span_processor", None)
+    processors = getattr(multi, "_span_processors", None)
+    if (
+        multi is None
+        or not isinstance(processors, tuple)
+        or processor not in processors
+    ):
+        logger.warning("Could not reorder span processors; rewrite runs last.")
+        return
+    multi._span_processors = (
+        processor,
+        *(p for p in processors if p is not processor),
+    )
+
+
 def setup_instrumentation():
     """
     Sets up Langfuse instrumentation for Google ADK.
@@ -152,7 +178,9 @@ def setup_instrumentation():
         GoogleADKInstrumentor().instrument()
         provider = cast(SDKTracerProvider, otel_trace.get_tracer_provider())
         provider.add_span_processor(RootSessionSpanProcessor())
-        provider.add_span_processor(TextExtractionSpanProcessor())
+        text_extraction = TextExtractionSpanProcessor()
+        provider.add_span_processor(text_extraction)
+        _move_processor_first(provider, text_extraction)
         logger.info("Langfuse instrumentation initialized.")
     else:
         logger.warning("Langfuse authentication failed. Skipping instrumentation.")

--- a/adk/cofacts_ai/tests/test_instrumentation.py
+++ b/adk/cofacts_ai/tests/test_instrumentation.py
@@ -1,10 +1,14 @@
-"""Unit tests for `TextExtractionSpanProcessor` and `_parts_text`.
+"""Unit tests for `TextExtractionSpanProcessor`, `_move_processor_first`, and
+`_parts_text`.
 
 The processor rewrites input.value/output.value from serialized JSON to plain
-text at span end (#14). Every test drives a real SDK TracerProvider with an
-InMemorySpanExporter and asserts on the EXPORTED span: on_end only receives a
-ReadableSpan snapshot, so proving the rewrite survives to export is the whole
-point -- a set_attribute-based implementation raises AttributeError there.
+text at span end (#14). The processor tests drive a real SDK TracerProvider in
+the production registration order (exporting processor first, rewrite second,
+then _move_processor_first) and assert on attributes snapshotted at export()
+time, the way OTLP serialization reads them -- on_end only receives a
+ReadableSpan snapshot, so a set_attribute-based implementation raises
+AttributeError, and a reference-holding exporter would hide ordering bugs.
+`_parts_text` and the fallback paths are exercised directly without a provider.
 """
 
 import json
@@ -145,10 +149,25 @@ class TestMoveProcessorFirst:
         assert attrs["input.value"] == "請查證這則訊息"
 
     def test_unexpected_provider_internals_do_not_raise(self):
-        # If the SDK renames its private fields, the reorder logs and degrades
-        # to the unreordered behavior instead of failing setup.
-        fake_provider = cast(TracerProvider, SimpleNamespace())
-        _move_processor_first(fake_provider, TextExtractionSpanProcessor())
+        # If the SDK renames its private fields or makes them read-only, the
+        # reorder logs and degrades to the unreordered behavior instead of
+        # failing setup. Covers both the missing-field and the frozen-setter
+        # paths.
+        processor = TextExtractionSpanProcessor()
+
+        missing_fields = cast(TracerProvider, SimpleNamespace())
+        _move_processor_first(missing_fields, processor)
+
+        class FrozenMulti:
+            @property
+            def _span_processors(self):
+                return (processor,)
+
+        frozen = cast(
+            TracerProvider, SimpleNamespace(_active_span_processor=FrozenMulti())
+        )
+        _move_processor_first(frozen, processor)
+        assert frozen._active_span_processor._span_processors == (processor,)
 
 
 class TestPartsText:

--- a/adk/cofacts_ai/tests/test_instrumentation.py
+++ b/adk/cofacts_ai/tests/test_instrumentation.py
@@ -10,15 +10,20 @@ point -- a set_attribute-based implementation raises AttributeError there.
 import json
 from collections.abc import Mapping
 from types import MappingProxyType, SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
-    InMemorySpanExporter,
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanExportResult,
 )
 
-from cofacts_ai.instrumentation import TextExtractionSpanProcessor, _parts_text
+from cofacts_ai.instrumentation import (
+    TextExtractionSpanProcessor,
+    _move_processor_first,
+    _parts_text,
+)
 
 JSON_MIME = "application/json"
 
@@ -41,18 +46,43 @@ FINAL_EVENT_OUTPUT = json.dumps(
 )
 
 
-def run_span(attributes: dict) -> Mapping[str, Any]:
-    """Ends one span carrying `attributes`; returns the EXPORTED attributes."""
+class SnapshotExporter(SpanExporter):
+    """Copies attributes at export() time, like OTLP serialization does.
+
+    InMemorySpanExporter holds the span by reference, so a mutation AFTER
+    export would still be visible when a test reads the attributes back. The
+    snapshot makes every test genuinely sensitive to processor order.
+    """
+
+    def __init__(self) -> None:
+        self.snapshots: list[dict] = []
+
+    def export(self, spans) -> SpanExportResult:
+        self.snapshots.extend(dict(span.attributes or {}) for span in spans)
+        return SpanExportResult.SUCCESS
+
+
+def run_span(attributes: dict, reorder: bool = True) -> Mapping[str, Any]:
+    """Ends one span carrying `attributes`; returns attributes as exported.
+
+    Replicates production registration order: the exporting processor is
+    registered first (Langfuse's is added inside get_client(), before ours),
+    then the rewrite processor, then _move_processor_first. SimpleSpanProcessor
+    exports synchronously at on_end, so with reorder=False the export
+    deterministically happens before the rewrite.
+    """
     provider = TracerProvider()
-    exporter = InMemorySpanExporter()
-    provider.add_span_processor(TextExtractionSpanProcessor())
+    exporter = SnapshotExporter()
     provider.add_span_processor(SimpleSpanProcessor(exporter))
+    processor = TextExtractionSpanProcessor()
+    provider.add_span_processor(processor)
+    if reorder:
+        _move_processor_first(provider, processor)
     tracer = provider.get_tracer("test")
     with tracer.start_as_current_span("span", attributes=attributes):
         pass
-    (span,) = exporter.get_finished_spans()
-    assert span.attributes is not None
-    return span.attributes
+    (snapshot,) = exporter.snapshots
+    return snapshot
 
 
 class TestTextExtractionSpanProcessor:
@@ -95,6 +125,30 @@ class TestTextExtractionSpanProcessor:
         )
         TextExtractionSpanProcessor().on_end(span)
         assert span._attributes["input.value"] == INVOCATION_INPUT
+
+
+class TestMoveProcessorFirst:
+    def test_without_reorder_export_wins_the_race(self):
+        # Documents why the reorder exists: with the production registration
+        # order and a synchronous exporter, export runs before the rewrite.
+        attrs = run_span(
+            {"input.value": INVOCATION_INPUT, "input.mime_type": JSON_MIME},
+            reorder=False,
+        )
+        assert attrs["input.value"] == INVOCATION_INPUT
+
+    def test_reorder_makes_rewrite_run_before_export(self):
+        attrs = run_span(
+            {"input.value": INVOCATION_INPUT, "input.mime_type": JSON_MIME},
+            reorder=True,
+        )
+        assert attrs["input.value"] == "請查證這則訊息"
+
+    def test_unexpected_provider_internals_do_not_raise(self):
+        # If the SDK renames its private fields, the reorder logs and degrades
+        # to the unreordered behavior instead of failing setup.
+        fake_provider = cast(TracerProvider, SimpleNamespace())
+        _move_processor_first(fake_provider, TextExtractionSpanProcessor())
 
 
 class TestPartsText:

--- a/adk/cofacts_ai/tests/test_instrumentation.py
+++ b/adk/cofacts_ai/tests/test_instrumentation.py
@@ -9,6 +9,7 @@ point -- a set_attribute-based implementation raises AttributeError there.
 
 import json
 from collections.abc import Mapping
+from types import MappingProxyType, SimpleNamespace
 from typing import Any
 
 from opentelemetry.sdk.trace import TracerProvider
@@ -83,6 +84,17 @@ class TestTextExtractionSpanProcessor:
     def test_span_without_input_output_is_ignored(self):
         attrs = run_span({"session.id": "s1"})
         assert attrs["session.id"] == "s1"
+
+    def test_mutation_failure_does_not_raise(self):
+        # A future SDK could hand on_end a read-only mapping; the rewrite must
+        # log and swallow the failure, never break span end.
+        span = SimpleNamespace(
+            _attributes=MappingProxyType(
+                {"input.value": INVOCATION_INPUT, "input.mime_type": JSON_MIME}
+            )
+        )
+        TextExtractionSpanProcessor().on_end(span)
+        assert span._attributes["input.value"] == INVOCATION_INPUT
 
 
 class TestPartsText:

--- a/adk/cofacts_ai/tests/test_instrumentation.py
+++ b/adk/cofacts_ai/tests/test_instrumentation.py
@@ -1,0 +1,111 @@
+"""Unit tests for `TextExtractionSpanProcessor` and `_parts_text`.
+
+The processor rewrites input.value/output.value from serialized JSON to plain
+text at span end (#14). Every test drives a real SDK TracerProvider with an
+InMemorySpanExporter and asserts on the EXPORTED span: on_end only receives a
+ReadableSpan snapshot, so proving the rewrite survives to export is the whole
+point -- a set_attribute-based implementation raises AttributeError there.
+"""
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from cofacts_ai.instrumentation import TextExtractionSpanProcessor, _parts_text
+
+JSON_MIME = "application/json"
+
+INVOCATION_INPUT = json.dumps(
+    {
+        "user_id": "u1",
+        "session_id": "s1",
+        "new_message": {"role": "user", "parts": [{"text": "請查證這則訊息"}]},
+    },
+    ensure_ascii=False,
+)
+
+FINAL_EVENT_OUTPUT = json.dumps(
+    {
+        "content": {"role": "model", "parts": [{"text": "查證結果如下"}]},
+        "author": "writer",
+        "id": "ev-1",
+    },
+    ensure_ascii=False,
+)
+
+
+def run_span(attributes: dict) -> Mapping[str, Any]:
+    """Ends one span carrying `attributes`; returns the EXPORTED attributes."""
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(TextExtractionSpanProcessor())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("test")
+    with tracer.start_as_current_span("span", attributes=attributes):
+        pass
+    (span,) = exporter.get_finished_spans()
+    assert span.attributes is not None
+    return span.attributes
+
+
+class TestTextExtractionSpanProcessor:
+    def test_input_value_rewritten_to_plain_text(self):
+        attrs = run_span(
+            {"input.value": INVOCATION_INPUT, "input.mime_type": JSON_MIME}
+        )
+        assert attrs["input.value"] == "請查證這則訊息"
+        assert attrs["input.mime_type"] == "text/plain"
+
+    def test_output_value_rewritten_from_final_event(self):
+        attrs = run_span(
+            {"output.value": FINAL_EVENT_OUTPUT, "output.mime_type": JSON_MIME}
+        )
+        assert attrs["output.value"] == "查證結果如下"
+        assert attrs["output.mime_type"] == "text/plain"
+
+    def test_non_json_value_untouched(self):
+        attrs = run_span({"input.value": "not json", "input.mime_type": JSON_MIME})
+        assert attrs["input.value"] == "not json"
+        assert attrs["input.mime_type"] == JSON_MIME
+
+    def test_json_without_parts_untouched(self):
+        payload = json.dumps({"error": "timeout", "message": "tool failed"})
+        attrs = run_span({"output.value": payload, "output.mime_type": JSON_MIME})
+        assert attrs["output.value"] == payload
+        assert attrs["output.mime_type"] == JSON_MIME
+
+    def test_span_without_input_output_is_ignored(self):
+        attrs = run_span({"session.id": "s1"})
+        assert attrs["session.id"] == "s1"
+
+
+class TestPartsText:
+    def test_joins_multiple_text_parts(self):
+        data = {"content": {"parts": [{"text": "第一段"}, {"text": "第二段"}]}}
+        assert _parts_text(data) == "第一段\n第二段"
+
+    def test_skips_thought_parts(self):
+        data = {
+            "content": {
+                "parts": [{"text": "內部思考", "thought": True}, {"text": "回覆"}]
+            }
+        }
+        assert _parts_text(data) == "回覆"
+
+    def test_image_only_parts_yield_none(self):
+        data = {
+            "new_message": {
+                "parts": [{"inline_data": {"mime_type": "image/webp", "data": "…"}}]
+            }
+        }
+        assert _parts_text(data) is None
+
+    def test_prefers_new_message_over_missing_content(self):
+        data = {"new_message": {"parts": [{"text": "使用者輸入"}]}}
+        assert _parts_text(data) == "使用者輸入"


### PR DESCRIPTION
Remaining backend half of #14: readable trace input/output. The other two parts
(trace-id sync via LangfuseTracingPlugin, feedback scoring via user-thumbs) are
already on master.

GoogleADKInstrumentor stamps input.value with the serialized run_async arguments
and output.value with the final Event JSON, so the Langfuse session view shows
raw JSON blobs. This adds TextExtractionSpanProcessor in instrumentation.py: at
span end it parses those payloads and replaces them with the joined text of
new_message.parts / content.parts, and flips the mime type to text/plain.
Thought parts are skipped (the writer runs with include_thoughts=True). Non-JSON
and no-text payloads (tool calls, image-only messages) are left untouched. Image
extraction is out of scope per the issue.

Kept backend-only, following the direction in #19 to isolate FE and BE changes.

Two deviations from the #19 sketch, both found by testing against the installed
packages:

1. on_end receives a ReadableSpan snapshot that has no set_attribute (OTel SDK
   1.38), so that approach raises AttributeError. The processor updates the
   span's attribute mapping in place, replacing existing keys only, wrapped in
   catch-and-log so a failure can never break span end.

2. Langfuse's BatchSpanProcessor is registered inside get_client(), before
   setup_instrumentation can add the rewrite processor, and processors run in
   registration order. A batch flush could therefore race the rewrite and
   export raw JSON. After registration the rewrite processor is moved to the
   front of the provider's processor list; if SDK internals ever change, this
   degrades to the previous order instead of failing setup.

Verification (offline, deterministic): 13 new tests in
tests/test_instrumentation.py replicate the production registration order and
export through an exporter that snapshots attributes at export() time, the way
OTLP serialization does. Covered: input and output rewrite, mime flip,
thought-part skipping, multi-part joining, rewrite-before-export ordering, and
negative controls (non-JSON, no-parts JSON, image-only, no input/output,
read-only attribute mapping, unexpected provider internals, and raw JSON being
exported when the reorder is absent). uv run pytest: 38 passed. ruff format,
ruff check, and ty: clean.

Pending: visual check of a real trace in the Langfuse session view.