### PR TITLE
Set Cloud Run request timeout to 900s (preview 300s cutoff, #84)

### DIFF
--- a/service.template.yaml
+++ b/service.template.yaml
@@ -15,6 +15,11 @@ spec:
         autoscaling.knative.dev/minScale: "0"
         autoscaling.knative.dev/maxScale: "3"
     spec:
+      # Request timeout for the Cloud Run revision. Without this, Cloud Run
+      # applies its 300s default, which cuts long multimodal writer↔verifier↔
+      # investigator loops mid-run with no final answer (see #84). 900s (15 min)
+      # gives ambiguous VIDEO/AUDIO adjudications room to converge.
+      timeoutSeconds: 900
       serviceAccountName: ${SERVICE_ACCOUNT_EMAIL}
       containers:
       - name: ingress


### PR DESCRIPTION
## What

Add `timeoutSeconds: 900` at `spec.template.spec` in `service.template.yaml` so the Cloud Run revision no longer falls back to the platform-default **300s** request timeout.

## Why

Per #84, long multimodal writer↔verifier↔investigator loops on hard-to-adjudicate VIDEO/AUDIO articles were being cut off at ~300s with **no final answer** (`trace.output` = null, no ERROR observation). The template never set a request timeout — the two existing `timeoutSeconds: 5` values are startup-probe settings, so Cloud Run applied its 300s default.

## Evidence (Langfuse trace analysis)

I scanned all Langfuse invocations and classified them by environment. The ~300s cutoff is a **Cloud Run (preview/staging)** phenomenon:

- **Preview (Cloud Run):** p95 latency is *exactly* 300.0s; long runs pile up at ~297–300s, **all with null output**, then a hard gap between 300–360s. Classic request-timeout fingerprint.
- **Production (GCE):** invocations run past 300s and still return an answer (e.g. 313.6s, 319.8s, 579.7s with output) — no hard 300s cap.

While confirming this I also found that URL-based environment classification is unreliable: at least one session pasted a `cofacts.tw` (production) link that was actually served by the **preview** backend (the article fetch hit `https://dev-api.cofacts.tw/graphql`). So some apparent "production" cutoffs are really mis-pasted preview runs.

This PR is the immediate mitigation for **preview** (item 1 in the issue discussion). Production is left to observe for now — its ingress is Cloudflare tunnel → TanStack, a separate path from the Cloud Run timeout, and any ~300s cutoffs there would need a different fix. Convergence / graceful-degradation work (issue items 2 & 3) is out of scope here.

## Validation

Rendered the template with placeholders substituted and parsed it:
- `spec.template.spec.timeoutSeconds` = `900`
- both startup-probe `timeoutSeconds` remain `5`
- YAML parses cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NiofAYieaggQQZuEskPw27

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiofAYieaggQQZuEskPw27)_