### PR TITLE
fix(deploy): set Cloud Run request timeout to 900s

### DIFF
--- a/service.template.yaml
+++ b/service.template.yaml
@@ -16,6 +16,7 @@ spec:
         autoscaling.knative.dev/maxScale: "3"
     spec:
       serviceAccountName: ${SERVICE_ACCOUNT_EMAIL}
+      timeoutSeconds: 900
       containers:
       - name: ingress
         image: ${FRONTEND_IMAGE}


### PR DESCRIPTION
Part of #84 (question 1).

The revision template in service.template.yaml sets no
spec.template.spec.timeoutSeconds, so the Cloud Run service (preview
environments, per discussion in #84) uses the default 300 s request timeout.
Long multimodal runs are cut off mid-loop with no final answer.

This sets timeoutSeconds: 900. Verified offline: the rendered template
(envsubst with placeholder values) parses, the rendered request timeout is
900, and both startupProbe timeoutSeconds values remain 5. The live revision
value was not inspected; gcloud run services describe can confirm it after
deploy.

The agent-level budget work (items 2 and 3 in #84) is intentionally not part
of this PR.