### PR TITLE
fix: bound verifier/investigator video calls with a client-side timeout

### DIFF
--- a/adk/cofacts_ai/agent.py
+++ b/adk/cofacts_ai/agent.py
@@ -278,7 +278,9 @@ ai_investigator = LlmAgent(
     generate_content_config=genai_types.GenerateContentConfig(
         thinking_config=genai_types.ThinkingConfig(
             thinking_level=genai_types.ThinkingLevel.MEDIUM
-        )
+        ),
+        # Long YouTube videos can otherwise hang with no client-side deadline.
+        http_options=genai_types.HttpOptions(timeout=240_000),
     ),
     before_model_callback=inject_youtube_filedata,
     after_model_callback=append_grounding_sources,
@@ -325,7 +327,9 @@ ai_verifier = LlmAgent(
     generate_content_config=genai_types.GenerateContentConfig(
         thinking_config=genai_types.ThinkingConfig(
             thinking_level=genai_types.ThinkingLevel.HIGH
-        )
+        ),
+        # Long YouTube videos can otherwise hang with no client-side deadline.
+        http_options=genai_types.HttpOptions(timeout=240_000),
     ),
     before_model_callback=[inject_youtube_filedata, inject_cofacts_media_filedata],
     after_model_callback=append_url_context_sources,


### PR DESCRIPTION
## Summary
- `ai_investigator` and `ai_verifier` (both use `inject_youtube_filedata` to have Gemini watch YouTube videos natively) had no client-side timeout on their `generate_content_config`, so a stalled Vertex AI call could hang indefinitely with no exception raised and nothing logged.
- Confirmed in production via Langfuse (session `7eb4bee2-...` and reproductions in `40bf59ba-...`): the same long video caused repeated ~125–300s hangs with 0 token usage and a `{"result": "<not specified>"}` tool response — i.e. no function-response event was ever produced, and no error surfaced anywhere (checked GCE `rumors-deploy-adk-1` container logs across all incidents — no ERROR/Exception/traceback lines at all).
- Root cause confirmed by reading the installed `google-adk`/`google-genai` source: `Gemini.api_client` (`google/adk/models/google_llm.py`) builds `HttpOptions` with no `timeout` set, and `AgentTool.run_async` has no try/except, so a hang has no path to becoming a catchable error.
- Fix: set `http_options=genai_types.HttpOptions(timeout=240_000)` (4 min) on both agents' `generate_content_config`. This is the ADK-native, already-supported mechanism (`GenerateContentConfig.http_options` is merged per-request over the client's own options) — no other code paths touched.

Re-tested against the same previously-failing video post-deploy: the verifier call succeeded within the new timeout window with a full, real claim inventory (high token usage matching genuine video ingestion), vs. the previous 0-token empty failures.

## Test plan
- [x] `uv run pytest cofacts_ai/tests/ -v` — 25 passed
- [x] `uv run ruff check .` / `uv run ty check .` — no new warnings introduced (2 pre-existing unrelated findings confirmed via `git stash` diff)
- [x] Deployed to `cofacts-prod` and manually reproduced the previously-failing video via Langfuse; verifier now completes with real content instead of a silent empty response
- [ ] Continue monitoring Langfuse for any case where the 240s timeout is actually hit, to confirm it surfaces as a catchable error through `on_tool_error_callback` (follow-up work, not blocking this PR)

Note: separately observed that very long videos (~3h) still get shallow/generic verifier output due to Gemini's default media-resolution context limits (~1h at default resolution). Decided not to address in this PR since 3h+ videos are rare in Cofacts articles — tracked as a known limitation, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)