### PR TITLE
docs(adr): record why Langfuse under-reports Vertex AI cost by ~2x

### DIFF
--- a/adk/scripts/langfuse_gcp_reconcile.py
+++ b/adk/scripts/langfuse_gcp_reconcile.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python
+"""
+Reconcile Langfuse-reported LLM cost against the GCP Vertex AI bill.
+
+Langfuse computes cost from `usageDetails` keys, matched *exactly* against the price keys of a
+model definition, at ingestion time. Any token that lands in a key with no price — or on an
+observation whose model name never resolved — is silently free. That makes it possible for
+Langfuse to under-report real spend by ~2x while looking perfectly healthy.
+
+This script quantifies that. It pulls generations from the Langfuse API, re-prices them using the
+effective per-token rates *derived from the billing CSV itself* (rather than hardcoded list
+prices, so it survives repricing and new models), and prints where the two sides diverge.
+
+It also emits two health metrics that work as a standing regression check, no CSV needed:
+
+  * bucket mismatch — share of generations where the priced usage keys don't sum to `total`.
+    Every such token is billed by Google and free in Langfuse.
+  * unpriced models — generations whose model name never resolved, so the whole call cost $0.
+
+Usage:
+
+    # full reconciliation against a bill
+    uv run python scripts/langfuse_gcp_reconcile.py \
+        --billing-csv ~/Downloads/ocf-ikalatv-20260701-20260731.csv \
+        --from 2026-07-01 --to 2026-08-01
+
+    # health check only (no bill needed) — non-zero exit if thresholds are breached
+    uv run python scripts/langfuse_gcp_reconcile.py --from 2026-07-01 --to 2026-08-01 \
+        --max-bucket-mismatch 0.02 --max-unpriced-models 0
+
+Reads LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY / LANGFUSE_BASE_URL from the environment, the
+same variables `adk/instrumentation.py` uses. Note the API key is project-scoped, so this only
+sees one Langfuse project per run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import re
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+import httpx
+
+# Langfuse stores the OTel attribute `llm.token_count.completion_details.reasoning` under this
+# usage key. No Langfuse-managed Gemini model definition prices it (they price `output_reasoning`
+# / `thoughtsTokenCount`), so thinking tokens are free unless we map them ourselves.
+REASONING_KEY = "completion_details.reasoning"
+
+# Modality words that separate the family prefix from the direction in a Vertex SKU description,
+# e.g. "Gemini 3.1 Flash Lite Global | Video | Input - Predictions".
+_MODALITIES = ("text", "video", "audio", "image")
+
+# SKU noise that isn't part of the model family name.
+_SKU_NOISE = re.compile(r"\b(ga|global|thinking|predictions)\b|\(.*?\)")
+
+# SKUs that aren't per-token chat generation and have no Langfuse counterpart.
+_NON_CHAT_SKU = re.compile(r"embedding|grounding with google search", re.I)
+
+
+def canonical_family(name: str) -> str:
+    """
+    Normalize a Vertex SKU description or a Langfuse model id to a shared family key.
+
+        "Gemini 3.1 Flash Lite Global Video Input - Predictions" -> "gemini 3.1 flash lite"
+        "gemini-3.1-flash-lite-preview"                          -> "gemini 3.1 flash lite"
+    """
+    text = name.strip().lower().replace("-", " ").replace("_", " ")
+    text = text.split(" - ")[0]
+    # Cut the SKU at its modality word, which always follows the family name.
+    for modality in _MODALITIES:
+        idx = text.find(f" {modality} ")
+        if idx != -1:
+            text = text[:idx]
+            break
+    text = _SKU_NOISE.sub(" ", text)
+    # Version-suffixed and preview model ids belong to their base family.
+    text = re.sub(r"\b(preview|exp|latest|\d{3,})\b", " ", text)
+    return " ".join(text.split())
+
+
+def sku_kind(sku: str) -> str:
+    """Classify a SKU as cached input, plain input, or output."""
+    low = sku.lower()
+    if "caching" in low:
+        return "cached"
+    if "output" in low:
+        return "output"
+    return "input"
+
+
+@dataclass
+class Bucket:
+    tokens: int = 0
+    cost: float = 0.0
+
+
+@dataclass
+class Family:
+    """One model family's billed tokens and cost, split by direction."""
+
+    buckets: dict[str, Bucket] = field(default_factory=lambda: defaultdict(Bucket))
+
+    @property
+    def cost(self) -> float:
+        return sum(b.cost for b in self.buckets.values())
+
+    def rate(self, *kinds: str) -> float:
+        """Effective $/token across the given buckets — blends the cache discount in."""
+        tokens = sum(self.buckets[k].tokens for k in kinds if k in self.buckets)
+        cost = sum(self.buckets[k].cost for k in kinds if k in self.buckets)
+        return cost / tokens if tokens else 0.0
+
+
+@dataclass
+class Bill:
+    families: dict[str, Family]
+    line_item_total: float = 0.0
+    non_chat: float = 0.0
+    #: The export's own "Filtered total" row, which is authoritative — GCP's per-row
+    #: "Unrounded subtotal" values don't always sum to it exactly.
+    stated_total: float | None = None
+
+    @property
+    def chat(self) -> float:
+        return self.line_item_total - self.non_chat
+
+
+def load_billing(path: str) -> Bill:
+    """Parse a GCP billing export grouped by SKU into per-family buckets."""
+    bill = Bill(families=defaultdict(Family))
+    with open(path, newline="") as handle:
+        for row in csv.DictReader(handle):
+            sku = (row.get("SKU description") or "").strip()
+            try:
+                cost = float(row.get("Unrounded subtotal ($)") or 0)
+            except ValueError:
+                continue
+            if not sku:
+                # Trailing summary rows: the label sits in a shifted column.
+                if "filtered total" in " ".join(v or "" for v in row.values()).lower():
+                    bill.stated_total = cost
+                continue
+            try:
+                tokens = int((row.get("Usage amount") or "0").replace(",", ""))
+            except ValueError:
+                continue
+            bill.line_item_total += cost
+            if _NON_CHAT_SKU.search(sku):
+                bill.non_chat += cost
+                continue
+            bucket = bill.families[canonical_family(sku)].buckets[sku_kind(sku)]
+            bucket.tokens += tokens
+            bucket.cost += cost
+    return bill
+
+
+def fetch_generations(
+    base_url: str, auth: tuple[str, str], start: str, end: str
+) -> list[dict]:
+    """Page through every GENERATION observation in the window."""
+    out: list[dict] = []
+    with httpx.Client(base_url=base_url, auth=auth, timeout=120.0) as client:
+        page = 1
+        while True:
+            resp = client.get(
+                "/api/public/observations",
+                params={
+                    "type": "GENERATION",
+                    "fromStartTime": start,
+                    "toStartTime": end,
+                    "limit": 100,
+                    "page": page,
+                },
+            )
+            resp.raise_for_status()
+            body = resp.json()
+            batch = body.get("data") or []
+            out.extend(batch)
+            meta = body.get("meta") or {}
+            print(
+                f"  page {page}/{meta.get('totalPages', '?')} ({len(out)} so far)",
+                file=sys.stderr,
+            )
+            if page >= (meta.get("totalPages") or 0) or not batch:
+                return out
+            page += 1
+
+
+@dataclass
+class Split:
+    """A generation's tokens, split into what Langfuse priced and what it silently dropped."""
+
+    input_priced: int = 0
+    input_tool_use: int = 0
+    output_priced: int = 0
+    output_reasoning: int = 0
+    bucket_mismatch: bool = False
+
+    @property
+    def input_total(self) -> int:
+        return self.input_priced + self.input_tool_use
+
+    @property
+    def output_total(self) -> int:
+        return self.output_priced + self.output_reasoning
+
+
+def split_usage(usage: dict) -> Split:
+    """
+    Separate a generation's tokens into priced and unpriced.
+
+    Two span shapes exist in practice. Fully-attributed spans set `output` from
+    `gen_ai.usage.output_tokens` (candidates only), so reasoning is *additive* and the leftover
+    `total - input - output - reasoning` is `toolUsePromptTokenCount` — a field Gemini reports
+    separately from `promptTokenCount`, bills at the input rate, and that no OTel attribute
+    carries. Truncated spans (no `gen_ai.*` attributes) instead set `output` from
+    `llm.token_count.completion`, which already includes reasoning; there, input + output == total
+    and nothing is missing.
+    """
+    total = usage.get("total") or 0
+    inp = usage.get("input") or 0
+    out = usage.get("output") or 0
+    reasoning = usage.get(REASONING_KEY) or 0
+
+    if inp + out == total:
+        # Truncated-span shape: `output` already subsumes reasoning, nothing unaccounted for.
+        return Split(input_priced=inp, output_priced=out)
+
+    leftover = total - inp - out - reasoning
+    return Split(
+        input_priced=inp,
+        input_tool_use=max(leftover, 0),
+        output_priced=out,
+        output_reasoning=reasoning,
+        bucket_mismatch=True,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--billing-csv",
+        help="GCP billing export grouped by SKU. Omit for health check only.",
+    )
+    parser.add_argument(
+        "--from", dest="start", required=True, help="inclusive start date, YYYY-MM-DD"
+    )
+    parser.add_argument(
+        "--to", dest="end", required=True, help="exclusive end date, YYYY-MM-DD"
+    )
+    parser.add_argument(
+        "--fallback-family",
+        default="gemini 3 flash",
+        help="family used to price generations whose model never resolved (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--max-bucket-mismatch",
+        type=float,
+        help="fail if the mismatch share exceeds this (0-1)",
+    )
+    parser.add_argument(
+        "--max-unpriced-models",
+        type=int,
+        help="fail if more than this many generations lack a model",
+    )
+    args = parser.parse_args()
+
+    public, secret = os.getenv("LANGFUSE_PUBLIC_KEY"), os.getenv("LANGFUSE_SECRET_KEY")
+    base_url = os.getenv("LANGFUSE_BASE_URL") or os.getenv("LANGFUSE_HOST")
+    if not (public and secret and base_url):
+        print(
+            "Set LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY and LANGFUSE_BASE_URL.",
+            file=sys.stderr,
+        )
+        return 2
+
+    start, end = f"{args.start}T00:00:00Z", f"{args.end}T00:00:00Z"
+    print(
+        f"Fetching generations {args.start} .. {args.end} from {base_url}",
+        file=sys.stderr,
+    )
+    generations = fetch_generations(base_url, (public, secret), start, end)
+    if not generations:
+        print("No generations in window.", file=sys.stderr)
+        return 0
+
+    # ---- Langfuse side -------------------------------------------------------------------
+    per_family: dict[str, Split] = defaultdict(Split)
+    per_agent: dict[str, Split] = defaultdict(Split)
+    reported = 0.0
+    unpriced_models = 0
+    mismatches = 0
+
+    for obs in generations:
+        split = split_usage(obs.get("usageDetails") or {})
+        reported += obs.get("calculatedTotalCost") or 0.0
+        mismatches += split.bucket_mismatch
+
+        model = obs.get("model")
+        if model:
+            family = canonical_family(model)
+        else:
+            family = args.fallback_family
+            unpriced_models += 1
+
+        agent = ((obs.get("metadata") or {}).get("attributes") or {}).get(
+            "gen_ai.agent.name"
+        ) or "<unattributed>"
+        for key, acc in ((family, per_family), (agent, per_agent)):
+            target = acc[key]
+            target.input_priced += split.input_priced
+            target.input_tool_use += split.input_tool_use
+            target.output_priced += split.output_priced
+            target.output_reasoning += split.output_reasoning
+
+    n = len(generations)
+    print(
+        f"\n{'=' * 92}\nLANGFUSE HEALTH — {n:,} generations, {args.start} .. {args.end}\n{'=' * 92}"
+    )
+    print(f"  reported cost                                   ${reported:>10.3f}")
+    print(
+        f"  bucket mismatch (priced keys != total)  {mismatches:>6,} / {n:,}  ({mismatches / n * 100:.1f}%)"
+    )
+    print(
+        f"  model never resolved -> whole call $0    {unpriced_models:>6,} / {n:,}  ({unpriced_models / n * 100:.1f}%)"
+    )
+
+    print("\n  tokens Langfuse holds but does not price, by agent:")
+    print(
+        f"    {'agent':<26}{'input priced':>14}{'TOOL-USE':>12}{'output':>10}{'REASONING':>12}"
+    )
+    for agent, s in sorted(
+        per_agent.items(), key=lambda kv: -kv[1].input_tool_use - kv[1].output_reasoning
+    ):
+        print(
+            f"    {agent:<26}{s.input_priced:>14,}{s.input_tool_use:>12,}"
+            f"{s.output_priced:>10,}{s.output_reasoning:>12,}"
+        )
+
+    # ---- reconcile against the bill ------------------------------------------------------
+    if args.billing_csv:
+        bill = load_billing(args.billing_csv)
+        print(f"\n{'=' * 92}\nRECONCILIATION vs {args.billing_csv}\n{'=' * 92}")
+        print(
+            "  A Langfuse API key is project-scoped, but the bill covers the whole billing\n"
+            "  account. A family with low coverage below is usage that lives in another Langfuse\n"
+            "  project (or isn't traced at all) — not necessarily a mapping bug.\n"
+        )
+        print(
+            f"  {'family':<26}{'GCP bill':>11}{'reconstructed':>15}{'coverage':>11}{'in $/Mtok':>12}"
+        )
+
+        reconstructed_total = 0.0
+        low_coverage = []
+        for name in sorted(set(bill.families) | set(per_family)):
+            fam, split = bill.families.get(name), per_family.get(name)
+            billed = fam.cost if fam else 0.0
+            in_rate = fam.rate("input", "cached") if fam else 0.0
+            recon = 0.0
+            if fam and split:
+                recon = split.input_total * in_rate + split.output_total * fam.rate(
+                    "output"
+                )
+            reconstructed_total += recon
+            coverage = recon / billed if billed else 0.0
+            if billed > 0.5 and coverage < 0.8:
+                low_coverage.append(name)
+            print(
+                f"  {name:<26}${billed:>10.3f}{('$%.3f' % recon):>15}"
+                f"{('%.0f%%' % (coverage * 100)):>11}{in_rate * 1e6:>12.4f}"
+            )
+
+        authoritative = (
+            bill.stated_total if bill.stated_total is not None else bill.line_item_total
+        )
+        pct = reconstructed_total / bill.chat * 100 if bill.chat else 0.0
+        print(
+            f"\n  GCP bill, per-token chat SKUs                   ${bill.chat:>10.3f}"
+        )
+        if bill.non_chat:
+            print(
+                f"  GCP bill, other SKUs (embeddings/grounding)      ${bill.non_chat:>10.3f}   [no Langfuse counterpart]"
+            )
+        if (
+            bill.stated_total is not None
+            and abs(bill.line_item_total - bill.stated_total) > 0.005
+        ):
+            print(
+                f"  GCP stated 'Filtered total'                      ${bill.stated_total:>10.3f}"
+                f"   [line items sum to ${bill.line_item_total:.3f}; GCP's own rounding]"
+            )
+        print(
+            f"  reconstructed from tokens Langfuse holds         ${reconstructed_total:>10.3f}   ({pct:.0f}% of chat SKUs)"
+        )
+        print(f"  Langfuse actually reports                        ${reported:>10.3f}")
+        print(
+            f"  {'UNDER-REPORTED (this project vs whole account)':<46} ${authoritative - reported:>10.3f}"
+        )
+        if low_coverage:
+            print(
+                f"\n  Low coverage, expected if another project owns it: {', '.join(low_coverage)}"
+            )
+        if unpriced_models:
+            print(
+                f"  {unpriced_models:,} generations with no model were priced as '{args.fallback_family}' (--fallback-family)."
+            )
+        print(
+            "\n  Cost is computed at ingestion and never backfilled, so fixing the mapping only\n"
+            "  affects generations ingested afterwards. This window stays wrong."
+        )
+
+    # ---- thresholds ----------------------------------------------------------------------
+    failures = []
+    if (
+        args.max_bucket_mismatch is not None
+        and mismatches / n > args.max_bucket_mismatch
+    ):
+        failures.append(
+            f"bucket mismatch {mismatches / n:.3f} > {args.max_bucket_mismatch}"
+        )
+    if (
+        args.max_unpriced_models is not None
+        and unpriced_models > args.max_unpriced_models
+    ):
+        failures.append(
+            f"unpriced models {unpriced_models} > {args.max_unpriced_models}"
+        )
+    if failures:
+        print("\nFAIL: " + "; ".join(failures), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/decisions/20260730-langfuse-usage-mapping.md
+++ b/docs/decisions/20260730-langfuse-usage-mapping.md
@@ -56,9 +56,28 @@ an `openinference-instrumentation-google-adk` upgrade that might silently undo i
   singles out **the one agent whose responses are streamed**. `src/routes/api/run-sse.ts` sends
   `streaming: true`, while `AgentTool` runs sub-agents non-streaming — and no null span carries a
   `gen_ai.response.finish_reasons` at all (against `["stop"]` on 94% of named spans), which is what a
-  partial/streamed response looks like. **Confirming that ADK's streaming path is the trigger still
-  needs the instrumentor source or a live repro** — but the proposed fix does not depend on it, since
-  we set the model name ourselves either way.
+  partial/streamed response looks like.
+
+  Reading the installed sources narrows the mechanism to one specific divergence. openinference
+  patches `base_llm_flow.trace_call_llm` (`openinference/instrumentation/google_adk/__init__.py:76-86`)
+  and its `_TraceCallLlm` wrapper calls the original first (`_wrappers.py:204`), then writes its own
+  attributes to `get_current_span()` (`:207`). ADK's `trace_call_llm`
+  (`google/adk/telemetry/tracing.py:265-347`) instead writes to the `span` **passed to it** by
+  `_call_llm_with_tracing`, and its very first statement is an unconditional
+  `span.set_attribute('gen_ai.system', 'gcp.vertex.agent')`.
+
+  On the writer's `call_llm` spans, the openinference attributes are present and **every** ADK
+  attribute is absent — and absent from the whole trace, not merely relocated. Dumping all 23
+  observations of one affected trace shows each sub-agent `call_llm` carrying both sets, while the
+  writer's three carry only openinference's. Since the wrapper cannot have run without also running
+  ADK's function, the two must be writing to **different span objects**: openinference to the
+  recording `call_llm` span we see, ADK to something that is discarding writes. That also explains the
+  attribute split exactly — the openinference attributes that survive are precisely the ones it sets
+  outside its `if llm_request:` branch (`openinference.span.kind`, `output.mime_type`,
+  `llm.token_count.*`), while `llm.model_name`, `llm.provider` and `input.value` all sit inside it.
+
+  **Pinning the exact line needs a debugger on a live streamed turn, not more log archaeology** — but
+  the proposed fix does not depend on it, since we set the model name ourselves either way.
 
   Ruled out for these spans: **user interruption.** cofacts.ai can abort a response mid-stream
   (`ChatInput` stop → `AbortController` in `src/lib/chatCache.ts` → `request.signal` forwarded to

--- a/docs/decisions/20260730-langfuse-usage-mapping.md
+++ b/docs/decisions/20260730-langfuse-usage-mapping.md
@@ -201,6 +201,8 @@ field the OTel attribute set drops:
 ```python
 # LangfuseTracingPlugin.after_model_callback
 um = llm_response.usage_metadata
+if um is None:
+    return  # a streamed partial — Gemini reports usage only at terminal points
 prompt, cached = um.prompt_token_count or 0, um.cached_content_token_count or 0
 get_client().update_current_generation(
     model=<the agent's model id>,                                            # cause 2
@@ -246,12 +248,23 @@ must be split rather than added, or cached tokens get double-counted.
   so `update_current_generation` targets the right observation. If it does not, the fallback is to
   set `langfuse.observation.model` / `langfuse.observation.usage_details` on the current span
   directly. **This must be verified during implementation, not assumed.**
-- Bad, because the root agent runs **streamed**, and if ADK invokes `after_model_callback` once per
-  partial response there, the callback must use only the final aggregated `usage_metadata` — Gemini
-  reports usage cumulatively per chunk, so writing on every call would multiply the count. Today
-  there is no such double counting to undo (the 290 truncated spans are distinct sequential turns:
-  0/96 multi-null traces share an identical `input`), so this is a risk the fix introduces, not one
-  it inherits. Assert the `sum(priced keys) == total` invariant on a streamed turn specifically.
+- Bad, because on the streamed root agent the callback fires **once per chunk**, not once per call.
+  `base_llm_flow.py:1169-1182` invokes `_handle_after_model_callback` inside
+  `async for llm_response in agen`, and in SSE mode that generator yields every partial plus a final
+  aggregated response. The `if um is None: return` guard above is therefore **load-bearing, not
+  defensive**: Gemini reports usage only at terminal points, so `usage_metadata` is `None` on the
+  partials and the guard is what makes the callback fire effectively once. Without it the callback
+  raises `AttributeError` on the first chunk of every streamed turn.
+
+  Note this is _not_ a double-counting risk, contrary to the obvious worry. Two independent reasons:
+  usage is not carried per chunk in the first place, and `update_current_generation` **overwrites**
+  `usage_details` rather than accumulating, so repeated calls are last-write-wins. The residual hazard
+  is the inverse — **clobbering** a good value with an empty one. `StreamingResponseAggregator.close()`
+  (`utils/streaming_utils.py`) returns the aggregated response carrying `self._usage_metadata`, but it
+  can also return `None` when there are no parts, in which case no terminal response is yielded at
+  all. The guard covers that too, by leaving whatever the last usage-bearing response wrote. Assert
+  the `sum(priced keys) == total` invariant on a streamed turn specifically.
+
 - Bad, because it cannot repair history: July stays wrong, and any fix is judged only on data
   ingested after deploy.
 - Neutral, because emitting `output_reasoning` ourselves makes the outcome of the cause-3 upstream

--- a/docs/decisions/20260730-langfuse-usage-mapping.md
+++ b/docs/decisions/20260730-langfuse-usage-mapping.md
@@ -46,8 +46,30 @@ an `openinference-instrumentation-google-adk` upgrade that might silently undo i
   (`llm.model_name`, `gen_ai.request.model`, `gen_ai.agent.name`, `input.value`, `session.id`).
   Langfuse resolves the model from `gen_ai.request.model` or `llm.model_name`; with both absent
   there is nothing to match a price against. 290 of 1,735 July generations (16.7%), spread across
-  the whole month, 4%–50% per day. **The upstream trigger inside the instrumentor is not yet
-  identified** — the proposed fix deliberately does not depend on knowing it.
+  the whole month, 4%–50% per day.
+
+  **These are the root agent's own turns.** Every one of the 290 is a child of an
+  `agent_run [writer]` AGENT span, and in an affected trace the writer's sub-agents — running
+  concurrently, inside the same trace — are instrumented perfectly, with `["stop"]` finish reasons
+  and correct model names. The split is per-invocation: 95 traces where the writer is truncated
+  throughout, 105 where it is named throughout, 15 mixed. So this is not random attribute loss; it
+  singles out **the one agent whose responses are streamed**. `src/routes/api/run-sse.ts` sends
+  `streaming: true`, while `AgentTool` runs sub-agents non-streaming — and no null span carries a
+  `gen_ai.response.finish_reasons` at all (against `["stop"]` on 94% of named spans), which is what a
+  partial/streamed response looks like. **Confirming that ADK's streaming path is the trigger still
+  needs the instrumentor source or a live repro** — but the proposed fix does not depend on it, since
+  we set the model name ourselves either way.
+
+  Ruled out for these spans: **user interruption.** cofacts.ai can abort a response mid-stream
+  (`ChatInput` stop → `AbortController` in `src/lib/chatCache.ts` → `request.signal` forwarded to
+  ADK's `/run_sse`, with nothing in `adk/` catching the resulting `CancelledError`), which is a
+  plausible-looking cause and would fit "truncated". It does not survive the data: 24 of 25 affected
+  traces have a final answer — a _higher_ rate than clean traces (19/25) — none carry `ERROR` level
+  or a status message, and the null spans within a trace run strictly back-to-back with `input`
+  growing to roughly the previous span's `total` (0/96 traces have them ending within 1s of each
+  other, and 0/96 share an identical `input`). That is a sequential agent loop that ran to
+  completion, not concurrent calls cut off at one instant.
+
 - [`gemini-3.5-flash` at $0 — `33b84a45`](https://langfuse.cofacts.tw/project/cmm0emerr0001qi07eugd0760/traces/33b84a45d25399a3a8475c1c08dc65cc) —
   all 30 `gemini-3.5-flash` generations (Jul 12–15) have `modelId = null` and $0, even though a
   correct managed definition ($1.50/$9.00 per Mtok) exists on the instance now. Cost is computed
@@ -224,6 +246,12 @@ must be split rather than added, or cached tokens get double-counted.
   so `update_current_generation` targets the right observation. If it does not, the fallback is to
   set `langfuse.observation.model` / `langfuse.observation.usage_details` on the current span
   directly. **This must be verified during implementation, not assumed.**
+- Bad, because the root agent runs **streamed**, and if ADK invokes `after_model_callback` once per
+  partial response there, the callback must use only the final aggregated `usage_metadata` — Gemini
+  reports usage cumulatively per chunk, so writing on every call would multiply the count. Today
+  there is no such double counting to undo (the 290 truncated spans are distinct sequential turns:
+  0/96 multi-null traces share an identical `input`), so this is a risk the fix introduces, not one
+  it inherits. Assert the `sum(priced keys) == total` invariant on a streamed turn specifically.
 - Bad, because it cannot repair history: July stays wrong, and any fix is judged only on data
   ingested after deploy.
 - Neutral, because emitting `output_reasoning` ourselves makes the outcome of the cause-3 upstream
@@ -329,6 +357,15 @@ separate Langfuse project — owns most of it.
     current cause, but both services can silently drop buffered spans on redeploy.
   - `adk/cofacts_ai/session_title.py:80-91` calls a raw `genai.Client()` outside
     `GoogleADKInstrumentor`, so session-title generation is billed but untraced.
+  - Confirm the streaming trigger behind cause 2 with a live repro: run one fact-check through
+    `/run_sse` and one through a non-streaming call, and compare whether the writer's `call_llm`
+    spans carry `llm.model_name` and a finish reason. If streaming is confirmed, that is worth an
+    openinference issue in its own right — it silently un-instruments the root agent of every
+    streamed ADK deployment, which is a far broader problem than our cost gap.
+  - Client aborts are unguarded end to end (`request.signal` → `CancelledError` inside ADK's Runner,
+    nothing in `adk/` catching it). Not the cause of any truncated span we found, but it does mean an
+    aborted run's spans depend entirely on ADK's internal cancellation handling. Worth a deliberate
+    look rather than leaving it to chance.
 - **External references**, in the order the argument uses them:
   - Gemini [`UsageMetadata`](https://ai.google.dev/api/generate-content#UsageMetadata) —
     `toolUsePromptTokenCount` is separate from `promptTokenCount` and counted in `totalTokenCount`;

--- a/docs/decisions/20260730-langfuse-usage-mapping.md
+++ b/docs/decisions/20260730-langfuse-usage-mapping.md
@@ -68,6 +68,47 @@ Aggregated, grouping unpriced tokens by `gen_ai.agent.name` localizes cause 1 pr
 **77.6% of July generations have `total != input + output`.** June shows the same shape (85.1%), so
 this is not a one-month artifact.
 
+### Why configuration cannot fix this
+
+The obvious first instinct is that this is a Langfuse pricing-table problem — set the prices up
+correctly and the numbers come right. It is worth writing down why that is false for the two largest
+causes, because it is the question anyone will ask first, and because a plausible-sounding claim
+circulates that `toolUsePromptTokenCount` is "automatically aggregated into the input usage type" by
+Langfuse's SDKs and OTel instrumentation. It is not, and there are three independent reasons:
+
+1. **The number never reaches Langfuse.** The complete attribute set of the `05b367a8` span above is
+   24 attributes; the missing 2,943,390 tokens appear in **none** of them. The only numeric token
+   attributes present are `gen_ai.usage.input_tokens` (1287), `gen_ai.usage.output_tokens` (729),
+   `llm.token_count.prompt` (1287), `llm.token_count.completion` (10692),
+   `llm.token_count.completion_details.reasoning` (9963) and `llm.token_count.total` (2955369). The
+   tool-use count survives only as an arithmetic residue inside `total`. Nothing downstream can
+   aggregate a value it never received.
+2. **The OpenInference vocabulary has no slot for it.** Its
+   [semantic conventions](https://arize-ai.github.io/openinference/spec/semantic_conventions.html)
+   define exactly eight `llm.token_count.*` attributes — `prompt`, `completion`, `total`,
+   `completion_details.reasoning`, `completion_details.audio`, `prompt_details.cache_read`,
+   `prompt_details.cache_write`, `prompt_details.audio`. **There is no tool-use attribute.** So this
+   is not the instrumentor forgetting to emit a field; the vocabulary it targets has nowhere to put
+   one. Fixing this upstream requires a spec change first, then a library change.
+3. **`total` is reserved, so it cannot be priced as a workaround.** Langfuse's docs define it as
+   "not a bucket itself but spans all buckets and equals their sum" — a derived aggregate, not a
+   priceable bucket. Buckets are assumed mutually exclusive with `total == sum(buckets)`, and our
+   spans violate that invariant on 77.6% of generations. A pricing table assigns prices to buckets;
+   it cannot invent a bucket that was never sent.
+
+Two related dead ends, for the record. `usageDetailPattern` in a pricing tier's conditions (e.g.
+`{"operator": "gt", "value": 200000, "usageDetailPattern": "(input|prompt|cached)"}`) selects which
+_already-present_ keys count toward a tier threshold — it does not extract or create usage keys.
+And cause 2 is unreachable by construction: model definitions match by regex against the model name,
+and there is no model name, so no pattern can ever apply.
+
+Langfuse's ingestion is likewise not a generic absorber — it is an allowlist of known key spellings
+(`extractGenericGenAiUsageDetails`). [langfuse#13571](https://github.com/langfuse/langfuse/issues/13571)
+is the same bug shape as our cause 3, on canonical OpenInference names: `prompt_details.cache_read`
+was passed through unrecognised, so cache tokens went unpriced and a production account under-reported
+cost by **~30%**. It was fixed by adding the spellings to the resolver chain. That precedent matters
+for how we split the work below.
+
 ## Decision Drivers
 
 - Cost per feature and per user has to be trustworthy in Langfuse, or we cannot see a runaway agent
@@ -83,29 +124,54 @@ this is not a one-month artifact.
 - Prefer a fix that needs no per-model Langfuse configuration, since model ids churn (four Gemini
   families appeared on this bill in one month) and a config step that must be repeated per model
   will be forgotten.
+- The causes sit at **different layers**, so one blanket answer is wrong. Cause 3 is a Langfuse-side
+  allowlist gap on a name that already exists in the OpenInference spec, with a merged fix precedent.
+  Cause 1 needs a new attribute in the spec before any library can carry it. Cause 2 is a bug in a
+  library we do not control. Only the last two need to be worked around locally.
 
 ## Considered Options
 
-- **Rely on the instrumentor; file the gaps upstream.** Report the missing
-  `toolUsePromptTokenCount` attribute and the truncated spans to
-  [openinference](https://github.com/Arize-ai/openinference) and wait.
+- **File the reasoning-key gap upstream with Langfuse (cause 3 only).** `completion_details.reasoning`
+  is already a canonical OpenInference name that Langfuse passes through without normalizing to
+  `output_reasoning`. Ask for the spelling to be added to the resolver chain, exactly as
+  [#13571](https://github.com/langfuse/langfuse/issues/13571) → #13572 did for
+  `prompt_details.cache_read`.
+- **File the tool-use gap upstream and wait (cause 1).** Requires a new `llm.token_count.*` attribute
+  in the [OpenInference spec](https://arize-ai.github.io/openinference/spec/semantic_conventions.html),
+  then an `openinference-instrumentation-google-adk` release emitting it, then Langfuse recognising
+  it — a three-party sequence.
 - **Add project-level custom model definitions that price the instrumentor's own key names.**
-  Langfuse lets user-defined models override managed ones, so define
-  `gemini-3-flash-preview` etc. with prices for `completion_details.reasoning` and
-  `prompt_details.audio` — the keys the instrumentor actually emits.
+  Langfuse lets user-defined models override managed ones, so define `gemini-3-flash-preview` etc.
+  with prices for `completion_details.reasoning` and `prompt_details.audio` — the keys the
+  instrumentor actually emits.
 - **Own the mapping in `LangfuseTracingPlugin`,** reading `llm_response.usage_metadata` in an
   `after_model_callback` and overwriting the current generation's model and `usage_details`.
 
 ## Decision Outcome
 
-Chosen option: **own the mapping in `LangfuseTracingPlugin`** — it is the only option that addresses
-all three causes, and the other two cannot.
+Chosen option: **own the mapping in `LangfuseTracingPlugin`**, and **also file the reasoning-key gap
+upstream** — the two are complementary, not alternatives.
 
-Pricing the instrumentor's key names (option 2) fixes thinking tokens and nothing else: for cause 1
-there is **no key to price**, because the tool-use tokens exist only inside `total`, and for cause 2
-there is **no model name to match**, so no definition can ever apply. Waiting on upstream (option 1)
-leaves ~$25/month mis-attributed indefinitely, and every day of delay is unrecoverable because
-Langfuse never backfills cost.
+Own the mapping, because it is the only option that reaches causes 1, 2 and 5. Custom model
+definitions cannot: for cause 1 there is **no key to price** (the tool-use tokens exist only inside
+the reserved `total`), for cause 2 there is **no model name to match**, and for cause 5 the
+`input_cached_tokens` bucket is never sent at all — you cannot discount a bucket you do not receive.
+Waiting on upstream for cause 1 means waiting on a spec change, a library release and a Langfuse
+release in sequence, while ~$18/month stays mis-attributed and every day of delay is unrecoverable
+because Langfuse never backfills.
+
+File cause 3 upstream anyway, because it is a genuinely different situation: the name already exists
+in the spec, Langfuse simply does not normalize it, and #13571 shows that class of report getting
+merged quickly. Our shim will emit `output_reasoning` and stop depending on the outcome either way,
+so this costs us one issue and benefits everyone using ADK with Langfuse.
+
+Deliberately **not** chosen for the main fix: custom model definitions. Beyond being unable to reach
+causes 1, 2 and 5, a user-defined definition appears to _replace_ rather than merge with the managed
+one (the docs say only that user definitions "take priority", which needs testing before relying on
+it), so it would mean hand-maintaining a ~20-key price map per model id, forever, re-done on every
+Google reprice. One narrow use does survive, and is worth keeping: **pre-registering a definition for
+a model id before deploying it**, as a safety net against exactly the `gemini-3.5-flash` silent-$0
+above, where this self-hosted instance's managed model list lagged Google's release.
 
 The proposed shape — `usage_metadata` is the authoritative `google.genai` object, carrying every
 field the OTel attribute set drops:
@@ -160,8 +226,12 @@ must be split rather than added, or cached tokens get double-counted.
   directly. **This must be verified during implementation, not assumed.**
 - Bad, because it cannot repair history: July stays wrong, and any fix is judged only on data
   ingested after deploy.
-- Neutral, because it leaves the underlying instrumentor bugs unreported. Filing them upstream is
-  still worth doing; it is just not a substitute.
+- Neutral, because emitting `output_reasoning` ourselves makes the outcome of the cause-3 upstream
+  issue irrelevant to us — good for independence, but it also removes our incentive to chase it. File
+  it anyway; it is a one-sided fix that helps everyone else on ADK plus Langfuse.
+- Neutral, because the tool-use and span-truncation bugs stay unreported unless someone files them.
+  Worth doing, but on a three-party timeline (spec, then library, then Langfuse), so it can never be
+  the thing we wait for.
 
 ## Confirmation
 
@@ -196,21 +266,36 @@ separate Langfuse project — owns most of it.
 
 ## Pros and Cons of the Options
 
-### Rely on the instrumentor; file upstream
+### File the reasoning-key gap upstream with Langfuse (cause 3)
 
-- Good, because the fix would land where it belongs and benefit every ADK user.
-- Good, because we carry no extra code.
-- Bad, because ~$25/month stays mis-attributed on an unknown timeline.
-- Bad, because Langfuse never backfills cost, so every day of waiting is permanent.
+- Good, because the name is already canonical in the OpenInference spec — Langfuse just needs to
+  normalize `completion_details.reasoning` to `output_reasoning`, a one-sided change with a merged
+  precedent in #13571 → #13572.
+- Good, because it benefits every ADK-plus-Langfuse user and costs us one issue.
+- Neutral, because our own shim makes us independent of the outcome either way.
+- Bad, because it reaches only ~$5.8 of the ~$25.5 gap, and only after a release.
+
+### File the tool-use gap upstream and wait (cause 1)
+
+- Good, because this is genuinely the right long-term home for it.
+- Bad, because it is a **three-party sequence**: a new attribute in the OpenInference spec, then an
+  instrumentor release emitting it, then Langfuse recognising the name. Any one of the three stalling
+  stalls the whole thing.
+- Bad, because ~$10.9/month keeps mis-attributing meanwhile, unrecoverably.
 
 ### Custom model definitions pricing the instrumentor's key names
 
 - Good, because it is pure configuration — no code, no upgrade risk.
 - Good, because it would correctly price thinking tokens and `prompt_details.audio`.
-- Bad, because it **cannot fix cause 1** — tool-use tokens live only in `total`, and pricing `total`
-  would double-count everything else in it.
-- Bad, because it **cannot fix cause 2** — with no model name, no definition ever matches.
-- Bad, because it needs a hand-maintained definition per model id, indefinitely.
+- Bad, because it **cannot fix cause 1** — the tool-use tokens live only in `total`, which Langfuse
+  defines as a derived sum rather than a priceable bucket.
+- Bad, because it **cannot fix cause 2** — with no model name, no `matchPattern` ever matches.
+- Bad, because it **cannot fix cause 5** — `input_cached_tokens` is never sent, and an absent bucket
+  cannot be discounted.
+- Bad, because it needs a hand-maintained ~20-key price map per model id, indefinitely, re-done on
+  every Google reprice — a user definition appears to replace rather than merge with the managed one.
+- Good, in one narrow role worth keeping: pre-registering a definition for a model id **before**
+  deploying it, as a safety net for when the instance's managed model list lags Google.
 
 ### Own the mapping in `LangfuseTracingPlugin`
 
@@ -244,13 +329,28 @@ separate Langfuse project — owns most of it.
     current cause, but both services can silently drop buffered spans on redeploy.
   - `adk/cofacts_ai/session_title.py:80-91` calls a raw `genai.Client()` outside
     `GoogleADKInstrumentor`, so session-title generation is billed but untraced.
-- **External references.** Gemini's
-  [`UsageMetadata`](https://ai.google.dev/api/generate-content#UsageMetadata) — confirms
-  `toolUsePromptTokenCount` is separate from `promptTokenCount`, and that `cachedContentTokenCount`
-  is a subset of it. Langfuse's
-  [token and cost tracking](https://langfuse.com/docs/observability/features/token-and-cost-tracking) —
-  confirms exact key matching, user-defined models overriding managed ones, cost computed at
-  ingestion, and no backfill.
+- **External references**, in the order the argument uses them:
+  - Gemini [`UsageMetadata`](https://ai.google.dev/api/generate-content#UsageMetadata) —
+    `toolUsePromptTokenCount` is separate from `promptTokenCount` and counted in `totalTokenCount`;
+    `cachedContentTokenCount` is a _subset_ of `promptTokenCount` (hence `prompt - cached`).
+  - [OpenInference semantic conventions](https://arize-ai.github.io/openinference/spec/semantic_conventions.html) —
+    the eight `llm.token_count.*` attributes, with **no tool-use attribute**. This is the spec-level
+    gap behind cause 1, and the reason a library-only fix is not possible.
+  - Langfuse
+    [token and cost tracking](https://langfuse.com/docs/observability/features/token-and-cost-tracking) —
+    usage keys match price keys _exactly_; buckets are mutually exclusive; `total` is "not a bucket
+    itself but spans all buckets and equals their sum"; user-defined models take priority over
+    managed ones; cost is computed at ingestion with **no backfill**.
+  - [langfuse#13571](https://github.com/langfuse/langfuse/issues/13571) (closed by #13572) — the
+    prior art for cause 3. Langfuse's `extractGenericGenAiUsageDetails` is an allowlist of key
+    spellings, not a generic absorber; canonical OpenInference `prompt_details.cache_read` went
+    unrecognised and under-reported a production account's cost by ~30%. Fixed by adding the
+    spellings to the resolver chain.
+  - Beware second-hand summaries here. A widely-surfaced claim holds that
+    `tool_use_prompt_token_count` is "automatically aggregated into the input usage type" when using
+    Langfuse's SDKs or OTel instrumentation. The three reasons above show it is not, and the sources
+    such summaries cite are themselves bug reports of this very symptom. Verify against the spec and
+    against a real span's attribute set, as the evidence section does.
 - This continues the observability thread listed under "To backfill" in
   [`index.md`](index.md): Langfuse instrumentation ([#8](https://github.com/cofacts/ai/pull/8)),
   session grouping ([#56](https://github.com/cofacts/ai/pull/56)), per-environment traces

--- a/docs/decisions/20260730-langfuse-usage-mapping.md
+++ b/docs/decisions/20260730-langfuse-usage-mapping.md
@@ -150,6 +150,43 @@ was passed through unrecognised, so cache tokens went unpriced and a production 
 cost by **~30%**. It was fixed by adding the spellings to the resolver chain. That precedent matters
 for how we split the work below.
 
+### We are on the official integration path
+
+Nothing above is the consequence of a misconfiguration on our side, and a future reader should not
+start from that assumption. Langfuse's
+[Google ADK guide](https://langfuse.com/integrations/frameworks/google-adk) recommends exactly what
+`adk/instrumentation.py` does — `pip install openinference-instrumentation-google-adk`, then
+`GoogleADKInstrumentor().instrument()` with the three `LANGFUSE_*` env vars. It presents no
+alternative and labels nothing else recommended. The gaps are in that path, not in our use of it.
+
+What differs is the regime it was validated in. The guide's example is a notebook: one agent, one
+run, non-streaming, success measured by "spans appear in the UI". Ours is a long-lived FastAPI
+service running a streamed multi-agent tree where the number that matters is a dollar figure. Three
+consequences follow, and each maps onto a cause above:
+
+- **openinference rewires ADK rather than observing it.** At `instrument()` it does
+  `setattr(base_llm_flow, "tracer", self._tracer)`, monkeypatches `trace_call_llm` and
+  `trace_tool_call`, and neuters the `runners` / `base_agent` / `telemetry.tracing` tracers with a
+  `_PassthroughTracer`. So the `call_llm` span is created by openinference's tracer while ADK's
+  `trace_call_llm` still writes to it through the `span` **parameter** and openinference writes
+  through **`get_current_span()`** — two writers holding two different references to "the span". That
+  is the structural fragility behind cause 2; it does not require anyone to have configured anything
+  wrongly.
+- **A tracer-provider race a notebook cannot have.** `get_fast_api_app()` calls
+  `set_tracer_provider()` itself, and OTel refuses to override an already-set provider — first caller
+  wins. `adk/main.py` therefore instruments _before_ building the app, deliberately and with a
+  comment. The guide never surfaces this hazard because there is no app in a notebook.
+- **Token usage, cost, and `StreamingMode.SSE` are not mentioned in the guide at all.** Cost
+  correctness was never in its scope, which is a sufficient explanation for why a ~2x error could sit
+  in the recommended path unremarked.
+
+One inversion worth recording, because it argues against the tempting "just use ADK's native OTel
+export instead" reaction: ADK's own `trace_call_llm` sets only `gen_ai.usage.input_tokens` and
+`gen_ai.usage.output_tokens` — **no total**. It is openinference's `llm.token_count.total` that made
+`total != input + output` visible and cause 1 discoverable at all. A cleaner native-OTel setup would
+have hidden ~$10.9/month with no signal to find it by. The path we are on is buggy but observable,
+which is the better of the two failure modes.
+
 ## Decision Drivers
 
 - Cost per feature and per user has to be trustworthy in Langfuse, or we cannot see a runaway agent
@@ -185,6 +222,8 @@ for how we split the work below.
   Langfuse lets user-defined models override managed ones, so define `gemini-3-flash-preview` etc.
   with prices for `completion_details.reasoning` and `prompt_details.audio` — the keys the
   instrumentor actually emits.
+- **Drop openinference and export ADK's native OTel spans to Langfuse's OTLP endpoint.** Removes the
+  monkeypatching and the two-writer arrangement behind cause 2 entirely.
 - **Own the mapping in `LangfuseTracingPlugin`,** reading `llm_response.usage_metadata` in an
   `after_model_callback` and overwriting the current generation's model and `usage_details`.
 
@@ -357,6 +396,21 @@ separate Langfuse project — owns most of it.
 - Good, in one narrow role worth keeping: pre-registering a definition for a model id **before**
   deploying it, as a safety net for when the instance's managed model list lags Google.
 
+### Drop openinference for ADK's native OTel export
+
+- Good, because it removes the monkeypatching and the span-parameter-versus-`get_current_span()`
+  split, which is the structural cause of the truncated spans.
+- Good, because ADK sets `gen_ai.request.model` unconditionally, so the model name would never go
+  missing.
+- Bad, because ADK sets only `gen_ai.usage.input_tokens` and `gen_ai.usage.output_tokens` — **no
+  total**, no reasoning, no cached, no tool-use. Cause 1 would become **undetectable**: without
+  `llm.token_count.total` there is nothing to compare against, and ~$10.9/month would go missing with
+  no signal at all. Strictly worse than a visible bug.
+- Bad, because it abandons the officially recommended path, so we would own every future integration
+  question ourselves.
+- Neutral, because it is orthogonal to the chosen fix: our plugin reads `usage_metadata` directly and
+  would keep working under either exporter.
+
 ### Own the mapping in `LangfuseTracingPlugin`
 
 - Good, because it fixes causes 1, 2, 3 and 5 in one place, from authoritative data.
@@ -410,6 +464,9 @@ separate Langfuse project — owns most of it.
     usage keys match price keys _exactly_; buckets are mutually exclusive; `total` is "not a bucket
     itself but spans all buckets and equals their sum"; user-defined models take priority over
     managed ones; cost is computed at ingestion with **no backfill**.
+  - Langfuse's [Google ADK integration guide](https://langfuse.com/integrations/frameworks/google-adk) —
+    the recommended path, which is the one we are on. Note what it does _not_ cover: token usage,
+    cost, and streaming.
   - [langfuse#13571](https://github.com/langfuse/langfuse/issues/13571) (closed by #13572) — the
     prior art for cause 3. Langfuse's `extractGenericGenAiUsageDetails` is an allowlist of key
     spellings, not a generic absorber; canonical OpenInference `prompt_details.cache_read` went

--- a/docs/decisions/20260730-langfuse-usage-mapping.md
+++ b/docs/decisions/20260730-langfuse-usage-mapping.md
@@ -1,0 +1,261 @@
+---
+status: 'proposed'
+date: 2026-07-30
+decision-makers: [MrOrz]
+consulted:
+informed:
+---
+
+# Map Gemini token usage ourselves in the ADK plugin, not via the OpenInference instrumentor
+
+## Context and Problem Statement
+
+July 2026 Vertex AI spend on billing account `ocf - ikalatv` was **$45.95**, but Langfuse reported
+only **$20.44** of Gemini cost across the two projects — **56% of real spend was invisible**. Since
+Langfuse is how we reason about per-feature and per-user cost, a 2x blind spot makes it useless for
+budgeting and, worse, useless for noticing a runaway agent.
+
+The instinct was that traces were being lost. **They were not.** Pulling all 1,735 July
+`GENERATION` observations from the `cofacts.ai` project and re-pricing them at the effective
+per-token rates derived from the billing CSV accounts for **$45.11 of the $45.95 bill (98%)**. The
+tokens are already in Langfuse. They are being priced at $0.
+
+This is a **cost-attribution bug, not a data-loss bug** — which is why the fix belongs in how we map
+usage, not in how we export spans.
+
+Scope: `adk/instrumentation.py` (the `LangfuseTracingPlugin` and `GoogleADKInstrumentor` wiring),
+the agents in `adk/cofacts_ai/agent.py` that carry server-side tools (`ai_verifier`'s `url_context`,
+`ai_investigator`'s `google_search`), and — as follow-up, not fixed here — `rumors-api`'s manual
+Langfuse mapping for transcripts. This record precedes the fix; it exists so the reasoning survives
+an `openinference-instrumentation-google-adk` upgrade that might silently undo it.
+
+### Langfuse evidence
+
+- [2.95M billed tokens priced as 2,016 — `05b367a8`](https://langfuse.cofacts.tw/project/cmm0emerr0001qi07eugd0760/traces/05b367a82ef86c044ce8a33f5f9e5e2c) —
+  an `ai_verifier` call (`url_context` over a page set). The span carries
+  `llm.token_count.prompt = 1287` and `llm.token_count.total = 2955369`; Langfuse stored
+  `{input: 1287, output: 729, completion_details.reasoning: 9963, total: 2955369}` and charged
+  **$0.0028**. The 2.94M-token difference is `usageMetadata.toolUsePromptTokenCount`, which Gemini
+  reports _separately from_ `promptTokenCount`, counts inside `totalTokenCount`, and Google bills at
+  the normal text-input rate. No OTel attribute carries it, so it only ever reaches Langfuse inside
+  `total` — a key with no price. This one mechanism is ~43% of the gap.
+- [A generation with no model name — `e9f23487`](https://langfuse.cofacts.tw/project/cmm0emerr0001qi07eugd0760/traces/e9f23487bb5ad686cff21342603aea98) —
+  `model = null` ⇒ `modelId = null` ⇒ `costDetails = {}` ⇒ **$0**, while carrying real tokens. These
+  are truncated spans: ~5.6 attributes against 25.4 on healthy ones, holding only the response side
+  (`llm.token_count.*`, `openinference.span.kind`, `output.mime_type`) and none of the request side
+  (`llm.model_name`, `gen_ai.request.model`, `gen_ai.agent.name`, `input.value`, `session.id`).
+  Langfuse resolves the model from `gen_ai.request.model` or `llm.model_name`; with both absent
+  there is nothing to match a price against. 290 of 1,735 July generations (16.7%), spread across
+  the whole month, 4%–50% per day. **The upstream trigger inside the instrumentor is not yet
+  identified** — the proposed fix deliberately does not depend on knowing it.
+- [`gemini-3.5-flash` at $0 — `33b84a45`](https://langfuse.cofacts.tw/project/cmm0emerr0001qi07eugd0760/traces/33b84a45d25399a3a8475c1c08dc65cc) —
+  all 30 `gemini-3.5-flash` generations (Jul 12–15) have `modelId = null` and $0, even though a
+  correct managed definition ($1.50/$9.00 per Mtok) exists on the instance now. Cost is computed
+  **at ingestion and never backfilled**, so these were ingested while this self-hosted instance's
+  managed model list still predated Gemini 3.5 Flash. They are permanently $0. Separately: that
+  model id appears nowhere in this repo on `master` — worth finding which revision ran it.
+
+Aggregated, grouping unpriced tokens by `gen_ai.agent.name` localizes cause 1 precisely — it is
+`url_context`, not grounding in general:
+
+| agent                            | generations | input priced | **tool-use (unpriced)** |  output | **reasoning (unpriced)** |
+| -------------------------------- | ----------: | -----------: | ----------------------: | ------: | -----------------------: |
+| `verifier` (`url_context`)       |         175 |    4,200,299 |          **29,279,079** | 163,958 |                  952,633 |
+| `investigator` (`google_search`) |         197 |    4,841,309 |                       0 | 208,903 |                  469,376 |
+| `writer`                         |         510 |   15,887,776 |                       0 | 303,945 |                  229,390 |
+| 4× `proofreader_*`               |         459 |      351,161 |                       0 | 494,566 |                  578,643 |
+
+**77.6% of July generations have `total != input + output`.** June shows the same shape (85.1%), so
+this is not a one-month artifact.
+
+## Decision Drivers
+
+- Cost per feature and per user has to be trustworthy in Langfuse, or we cannot see a runaway agent
+  until the bill arrives a month later.
+- Langfuse matches usage keys against price keys **exactly**; an unmatched key is silently free, not
+  an error. Nothing surfaces this — the dashboard looks healthy while under-reporting 2x.
+- Cost is computed **at ingestion and never backfilled**. Every day we do not fix this is
+  permanently mis-priced, and no fix can repair history.
+- `usageMetadata` from `google-genai` is authoritative and already in hand at the callback boundary;
+  the OTel attribute set the instrumentor emits is a lossy projection of it.
+- Whatever we do must survive an `openinference-instrumentation-google-adk` upgrade — silently
+  reverting to lossy usage is the failure mode this record exists to prevent.
+- Prefer a fix that needs no per-model Langfuse configuration, since model ids churn (four Gemini
+  families appeared on this bill in one month) and a config step that must be repeated per model
+  will be forgotten.
+
+## Considered Options
+
+- **Rely on the instrumentor; file the gaps upstream.** Report the missing
+  `toolUsePromptTokenCount` attribute and the truncated spans to
+  [openinference](https://github.com/Arize-ai/openinference) and wait.
+- **Add project-level custom model definitions that price the instrumentor's own key names.**
+  Langfuse lets user-defined models override managed ones, so define
+  `gemini-3-flash-preview` etc. with prices for `completion_details.reasoning` and
+  `prompt_details.audio` — the keys the instrumentor actually emits.
+- **Own the mapping in `LangfuseTracingPlugin`,** reading `llm_response.usage_metadata` in an
+  `after_model_callback` and overwriting the current generation's model and `usage_details`.
+
+## Decision Outcome
+
+Chosen option: **own the mapping in `LangfuseTracingPlugin`** — it is the only option that addresses
+all three causes, and the other two cannot.
+
+Pricing the instrumentor's key names (option 2) fixes thinking tokens and nothing else: for cause 1
+there is **no key to price**, because the tool-use tokens exist only inside `total`, and for cause 2
+there is **no model name to match**, so no definition can ever apply. Waiting on upstream (option 1)
+leaves ~$25/month mis-attributed indefinitely, and every day of delay is unrecoverable because
+Langfuse never backfills cost.
+
+The proposed shape — `usage_metadata` is the authoritative `google.genai` object, carrying every
+field the OTel attribute set drops:
+
+```python
+# LangfuseTracingPlugin.after_model_callback
+um = llm_response.usage_metadata
+prompt, cached = um.prompt_token_count or 0, um.cached_content_token_count or 0
+get_client().update_current_generation(
+    model=<the agent's model id>,                                            # cause 2
+    usage_details={
+        "input": prompt - cached + (um.tool_use_prompt_token_count or 0),    # cause 1
+        "input_cached_tokens": cached,                                       # cause 5
+        "output": um.candidates_token_count or 0,
+        "output_reasoning": um.thoughts_token_count or 0,                    # cause 3
+    },
+)
+```
+
+Two choices in there are the reason this needs **no Langfuse configuration change at all**, and both
+are easy to get wrong later:
+
+- **Fold `tool_use_prompt_token_count` into `input`.** Google bills it at the plain input rate, and
+  `input` is already priced in every managed Gemini definition. A dedicated `input_tool_use` key
+  would read better in the UI but would require custom model definitions for every model — the
+  churn we are trying to avoid.
+- **Emit `output_reasoning` and `input_cached_tokens`, not the instrumentor's
+  `completion_details.reasoning`.** Those two key names already carry correct prices in the managed
+  `gemini-3-flash-preview`, `gemini-3.1-flash-lite` and `gemini-3.5-flash` definitions. This is a
+  pure key-naming fix — the prices were never wrong.
+
+Note `prompt - cached`: Gemini's `promptTokenCount` _includes_ `cachedContentTokenCount`, so they
+must be split rather than added, or cached tokens get double-counted.
+
+### Consequences
+
+- Good, because usage comes from the authoritative `google-genai` object instead of a lossy OTel
+  projection, so tool-use and thinking tokens are priced for the first time.
+- Good, because it repairs the truncated `model = null` spans **without needing to know why they
+  truncate** — we set the model name ourselves.
+- Good, because cached tokens finally get their 90% discount. Langfuse currently _over_-charges here
+  (23.37M tokens at full rate: $11.69 instead of $1.09, ~$3.7 of overstatement), which partially
+  masks the under-reporting and is why the naive gap looks like $25.5 rather than $28.6.
+- Good, because it needs no per-model Langfuse configuration, so a new Gemini family prices
+  correctly on arrival as long as a managed definition exists.
+- Bad, because we now carry a shim that duplicates what the instrumentor should do, and it must be
+  re-verified on every `openinference-instrumentation-google-adk` bump — including the possibility
+  that a future version fixes this and we start double-counting.
+- Bad, because it depends on `after_model_callback` running inside the OpenInference `call_llm` span
+  so `update_current_generation` targets the right observation. If it does not, the fallback is to
+  set `langfuse.observation.model` / `langfuse.observation.usage_details` on the current span
+  directly. **This must be verified during implementation, not assumed.**
+- Bad, because it cannot repair history: July stays wrong, and any fix is judged only on data
+  ingested after deploy.
+- Neutral, because it leaves the underlying instrumentor bugs unreported. Filing them upstream is
+  still worth doing; it is just not a substitute.
+
+## Confirmation
+
+`adk/scripts/langfuse_gcp_reconcile.py` reproduces the whole analysis above and doubles as the
+regression check. It re-prices generations at rates **derived from the billing CSV** rather than
+hardcoded list prices, so it keeps working when Google reprices or a new model appears:
+
+```
+uv run python scripts/langfuse_gcp_reconcile.py \
+    --billing-csv <export grouped by SKU> --from 2026-07-01 --to 2026-08-01
+```
+
+It prints the per-family GCP-vs-reconstructed table with a coverage column, the per-agent unpriced
+token table above, and two health metrics that need no CSV:
+
+- **bucket mismatch** — share of generations where the priced keys don't sum to `total`. This is the
+  single best invariant: `input + output + input_cached_tokens + output_reasoning == total` should
+  hold for every generation. Today it fails on **77.6%**.
+- **unpriced models** — generations whose model never resolved. Today **290**.
+
+Both should be ~0 after the fix, so it can run periodically and fail loudly:
+
+```
+uv run python scripts/langfuse_gcp_reconcile.py --from … --to … \
+    --max-bucket-mismatch 0.02 --max-unpriced-models 0     # exits 1 on breach
+```
+
+One caveat the script prints for itself: a Langfuse API key is **project-scoped** while the bill
+covers the whole billing account, so per-family coverage below 100% may just mean another project
+owns that usage. In July, `gemini 3.1 flash lite` shows 26% coverage because `rumors-api` — a
+separate Langfuse project — owns most of it.
+
+## Pros and Cons of the Options
+
+### Rely on the instrumentor; file upstream
+
+- Good, because the fix would land where it belongs and benefit every ADK user.
+- Good, because we carry no extra code.
+- Bad, because ~$25/month stays mis-attributed on an unknown timeline.
+- Bad, because Langfuse never backfills cost, so every day of waiting is permanent.
+
+### Custom model definitions pricing the instrumentor's key names
+
+- Good, because it is pure configuration — no code, no upgrade risk.
+- Good, because it would correctly price thinking tokens and `prompt_details.audio`.
+- Bad, because it **cannot fix cause 1** — tool-use tokens live only in `total`, and pricing `total`
+  would double-count everything else in it.
+- Bad, because it **cannot fix cause 2** — with no model name, no definition ever matches.
+- Bad, because it needs a hand-maintained definition per model id, indefinitely.
+
+### Own the mapping in `LangfuseTracingPlugin`
+
+- Good, because it fixes causes 1, 2, 3 and 5 in one place, from authoritative data.
+- Good, because it reuses key names that already carry correct managed prices — no config.
+- Neutral, because the plugin already exists for trace-id stamping; this is one more callback, not
+  new machinery.
+- Bad, because it must be re-verified on instrumentor upgrades, and could double-count if upstream
+  fixes this.
+
+## More Information
+
+- **Not the cause, but worth knowing.** Ruled out during the investigation: sampling (no sampler
+  config in either repo; Langfuse defaults to 100%); lost traces (neither repo calls
+  `flush()`/`shutdownAsync()` and both run on scale-to-zero Cloud Run / pm2 — a real latent risk,
+  but token capture reconciles at ~96%, leaving only ~$0.8 residual); and the two Flash Lite names
+  in the dashboard, which is just `rumors-api`'s `a8c03e1` replacing a retired
+  `gemini-3.1-flash-lite-preview` on 2026-07-17 — both names carry identical correct prices.
+- **Follow-ups this record does not fix:**
+  - `rumors-api` `src/graphql/util.js:940-946` reads only `promptTokenCount` and
+    `candidatesTokenCount` out of `usageMetadata`, dropping `thoughtsTokenCount`,
+    `cachedContentTokenCount` and `promptTokensDetails`. For a transcription feature that matters:
+    Vertex bills Flash Lite **audio input at $0.50/Mtok against text at $0.25** — 3.78M audio and
+    9.23M video tokens in July. Its `thinkingConfig: { thinkingBudget: 0 }` is a Gemini 2.5 holdover
+    that does not reliably disable thinking on Gemini 3.x.
+  - `rumors-api`'s `transcribeAV` opens its generation _before_ the API call with no `try/catch`, so
+    a failed attempt never gets `.end()`-ed — no usage, no cost, no error level. The Jul 9–17
+    retired-model incident produced a week of these.
+  - Flush on shutdown in both services, plus `run.googleapis.com/cpu-throttling: "false"` in
+    `service.template.yaml` so the OTel exporter still has CPU after a response finishes. Not the
+    current cause, but both services can silently drop buffered spans on redeploy.
+  - `adk/cofacts_ai/session_title.py:80-91` calls a raw `genai.Client()` outside
+    `GoogleADKInstrumentor`, so session-title generation is billed but untraced.
+- **External references.** Gemini's
+  [`UsageMetadata`](https://ai.google.dev/api/generate-content#UsageMetadata) — confirms
+  `toolUsePromptTokenCount` is separate from `promptTokenCount`, and that `cachedContentTokenCount`
+  is a subset of it. Langfuse's
+  [token and cost tracking](https://langfuse.com/docs/observability/features/token-and-cost-tracking) —
+  confirms exact key matching, user-defined models overriding managed ones, cost computed at
+  ingestion, and no backfill.
+- This continues the observability thread listed under "To backfill" in
+  [`index.md`](index.md): Langfuse instrumentation ([#8](https://github.com/cofacts/ai/pull/8)),
+  session grouping ([#56](https://github.com/cofacts/ai/pull/56)), per-environment traces
+  ([#115](https://github.com/cofacts/ai/pull/115)). The `RootSessionSpanProcessor` in
+  `adk/instrumentation.py` is a prior instance of the same pattern — a local shim compensating for
+  an [openinference bug](https://github.com/Arize-ai/openinference/issues/3117) — so this would be
+  the second such workaround in that file, which is itself a signal worth revisiting if a third
+  appears.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -7,6 +7,7 @@ this format is itself a record — the 2026-07-23 entry below.
 
 | Date       | Decision                                                                                               |
 | ---------- | ------------------------------------------------------------------------------------------------------ |
+| 2026-07-30 | [Map Gemini token usage ourselves in the ADK plugin](20260730-langfuse-usage-mapping.md)               |
 | 2026-07-23 | [Use Markdown Any Decision Records (MADR)](20260723-use-markdown-any-decision-records.md)              |
 | 2026-06-06 | [Multimodal media perception on Vertex AI](20260606-multimodal-perception-vertex-ai.md)                |
 | 2026-06-03 | [Propagate the auth token to ADK via header + ContextVar](20260603-auth-token-contextvar.md)           |
@@ -37,7 +38,8 @@ Significant decisions still embedded in PRs and code comments, not yet written u
 
 - **Observability** — Langfuse instrumentation ([#8](https://github.com/cofacts/ai/pull/8)),
   correct session grouping ([#56](https://github.com/cofacts/ai/pull/56)), per-environment
-  traces ([#115](https://github.com/cofacts/ai/pull/115)).
+  traces ([#115](https://github.com/cofacts/ai/pull/115)). Cost attribution on top of these is
+  already recorded — see [`20260730-langfuse-usage-mapping`](20260730-langfuse-usage-mapping.md).
 - **Frontend** — the `parts[]` message model + SSE state machine
   ([#21](https://github.com/cofacts/ai/pull/21)); openapi-fetch + server functions
   ([#18](https://github.com/cofacts/ai/pull/18)).


### PR DESCRIPTION
## Why

July 2026 Vertex AI spend on `ocf - ikalatv` was **$45.95**, but Langfuse reported only **$20.44** of Gemini cost across the two projects — 56% of real spend invisible. That makes Langfuse useless for budgeting and, worse, useless for noticing a runaway agent.

The instinct was lost traces. **It wasn't.** Pulling all 1,735 July `GENERATION` observations from the `cofacts.ai` project and re-pricing them at rates derived from the billing CSV accounts for **$45.11 of the $45.95 bill (98%)**. The tokens are already in Langfuse — they're being priced at $0. This is a cost-attribution bug, not data loss, which is why the fix belongs in how usage is mapped rather than in how spans are exported.

**No runtime code changes.** The ADR is `status: proposed` and records the recommended fix; this PR is the finding plus the tooling to re-check it.

## Root causes

| # | cause | share of gap |
|---|---|---|
| 1 | `toolUsePromptTokenCount` never priced | ~43% |
| 2 | 290 generations (16.7%) arrive with no model name → whole call $0 | ~29% |
| 3 | thinking tokens land under an unpriced key name | ~22% |
| 4 | `gemini-3.5-flash` never resolved to a definition (permanently $0) | ~7% |

**Cause 1** is the big one. Gemini reports `toolUsePromptTokenCount` *separately from* `promptTokenCount`, counts it inside `totalTokenCount`, and Google bills it at the normal text-input rate — but no OTel attribute carries it, so it only ever reaches Langfuse inside `total`, a key with no price. One observation carried 2,955,369 billed tokens and was priced as 2,016 (**$0.0028**). **77.6% of July generations have `total != input + output`.**

Grouping the unpriced tokens by `gen_ai.agent.name` localizes it precisely — it's `url_context`, not grounding in general:

| agent | generations | input priced | **tool-use (unpriced)** | **reasoning (unpriced)** |
| --- | --: | --: | --: | --: |
| `verifier` (`url_context`) | 175 | 4,200,299 | **29,279,079** | 952,633 |
| `investigator` (`google_search`) | 197 | 4,841,309 | 0 | 469,376 |
| `writer` | 510 | 15,887,776 | 0 | 229,390 |
| 4× `proofreader_*` | 459 | 351,161 | 0 | 578,643 |

**Cause 2** is localized to the **streamed root agent**. All 290 are children of an `agent_run [writer]` span; in an affected trace the sub-agents running concurrently are instrumented perfectly. openinference patches `base_llm_flow.trace_call_llm` and writes to `get_current_span()`, while ADK's own `trace_call_llm` writes to the `span` **passed to it** — and on the writer's spans every ADK attribute is missing from the whole trace, so the two are writing to different span objects. That also explains why it's the *model name* that vanishes: the surviving openinference attributes are exactly those set outside its `if llm_request:` branch. User interruption was considered and ruled out (24/25 affected traces have a final answer — more than clean traces).

**Cause 3** is a one-key mismatch: the instrumentor emits `completion_details.reasoning`, but the managed Gemini definitions price `output_reasoning` / `thoughtsTokenCount`, and Langfuse matches usage keys *exactly*. The prices were never wrong — only the key name.

Counteracting all of the above, Langfuse *over*-charges ~$3.7 on cached tokens (it prices them at full rate while GCP discounts 90%), which is why the naive gap reads $25.5 rather than $28.6.

Ruled out: sampling (none configured), lost traces (token capture reconciles at ~96%), and the two Flash Lite names in the dashboard (just `rumors-api` replacing a retired `-preview` id on Jul 17).

## Two things reviewers will want to know up front

**This is the officially recommended integration.** Langfuse's [Google ADK guide](https://langfuse.com/integrations/frameworks/google-adk) recommends exactly what `adk/instrumentation.py` does, and presents no alternative. Nothing here is a misconfiguration. What differs is the regime the guide was validated in — a notebook, one agent, one run, non-streaming, success measured by "spans appear in the UI" — versus a long-lived FastAPI service running a streamed multi-agent tree where the number that matters is a dollar figure. The guide never mentions token usage, cost, or streaming.

**A pricing table can't fix it,** which is the first thing anyone proposes, and a plausible-sounding claim circulates that `toolUsePromptTokenCount` is automatically aggregated into the input usage type. Three independent reasons it isn't: the value reaches Langfuse in **no attribute at all** (the span's full 24-attribute set doesn't contain it — it survives only as an arithmetic residue inside `total`); the OpenInference spec defines exactly eight `llm.token_count.*` attributes and **none is for tool use**, so it's a vocabulary gap needing a spec change before a library change; and `total` is a **reserved derived key** ("spans all buckets and equals their sum"), so it can't be priced as a workaround.

## What's here

- **`docs/decisions/20260730-langfuse-usage-mapping.md`** — MADR weighing five options. Chosen, in two complementary parts: **own the mapping** in the existing `LangfuseTracingPlugin` (reading `llm_response.usage_metadata` directly — the only thing that reaches causes 1, 2 and 5), **and file the reasoning-key gap upstream** with Langfuse, since that one is an allowlist omission on a name the spec already defines, with a merged precedent in [langfuse#13571](https://github.com/langfuse/langfuse/issues/13571) → #13572. Rejected: waiting on upstream for cause 1 (needs spec, library and Langfuse releases in sequence); custom model definitions for the main fix (kept only for pre-registering a model id before deploying it, as a safety net for when the instance's managed model list lags Google — exactly what made `gemini-3.5-flash` silently $0); and dropping openinference for ADK's native OTel export, which is **worse** — ADK sets only input and output token counts and no total, so cause 1 would become *undetectable* rather than merely unpriced.
- **`adk/scripts/langfuse_gcp_reconcile.py`** — reproduces the analysis and doubles as a regression check. Derives effective $/Mtok *from the billing CSV* rather than hardcoding list prices, so it survives repricing and new models.

## Verification

```
cd adk && uv run python scripts/langfuse_gcp_reconcile.py \
    --billing-csv <export grouped by SKU> --from 2026-07-01 --to 2026-08-01
```

Reproduces the numbers above: $45.947 billed / $39.880 reconstructed for this project / $17.305 reported, 1,346/1,735 bucket mismatch, 290 unpriced models. June reproduces the same shape (85.1% mismatch), so it isn't a one-month artifact.

Two health metrics need no CSV and work as a standing check — `input + output + input_cached_tokens + output_reasoning == total` should hold for every generation, and today fails on 77.6%:

```
uv run python scripts/langfuse_gcp_reconcile.py --from … --to … \
    --max-bucket-mismatch 0.02 --max-unpriced-models 0     # exits 1 on breach
```

`ruff check` / `ruff format --check` / `ty check` / repo-wide `prettier --check .` / `pytest` (32 passed) all pass.

Two caveats the script surfaces for itself, both easy to misread otherwise:

- A Langfuse API key is **project-scoped** while the bill covers the whole account, so it prints per-family coverage. Flash Lite shows 26% because `rumors-api` is a separate Langfuse project — not a mapping bug.
- The CSV's line items sum to $46.326 while its own "Filtered total" says $45.947, a rounding artifact in Google's export. The script reports the stated total and flags the difference.

Note Langfuse computes cost **at ingestion and never backfills**, so July stays wrong regardless — any fix is judged only on data ingested after deploy.

## Follow-ups recorded but not fixed here

- `rumors-api` `src/graphql/util.js:940-946` reads only `promptTokenCount`/`candidatesTokenCount`, dropping `thoughtsTokenCount` and the per-modality split — significant when Vertex bills Flash Lite audio input at 2× text. Its `transcribeAV` also never `.end()`s a generation when the API call throws.
- Confirm the streaming trigger behind cause 2 with a live repro. If confirmed it deserves an openinference issue in its own right — it silently un-instruments the root agent of every streamed ADK deployment, well beyond our cost gap.
- Flush on shutdown in both services (neither calls it today) plus `cpu-throttling: "false"`. Client aborts are also unguarded end to end — not the cause of anything found here, but left to chance.
- `adk/cofacts_ai/session_title.py` calls a raw `genai.Client()` outside the instrumentor.
- Open question: `gemini-3.5-flash` ran Jul 12–15 and cost $1.70, but that model id is nowhere in this repo on `master`. Worth finding which revision ran it.
