### PR TITLE
feat(deploy): run url-resolver as a Cloud Run sidecar

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,9 +149,24 @@ jobs:
           SERVICE_ACCOUNT_EMAIL: ${{ secrets.SERVICE_ACCOUNT_EMAIL }}
           GC_PROJECT_ID: ${{ secrets.GC_PROJECT_ID }}
           COFACTS_API_URL: ${{ secrets.COFACTS_API_URL }}
+          # Where the url-resolver sidecar runs puppeteer's browser. Leave the
+          # repo variable unset for in-container chromium; set it to `cloudflare`
+          # to use Cloudflare Browser Rendering (needs the two secrets below).
+          # Unset substitutes to an empty string, which url-resolver reads as
+          # `local` — so this is inert until the variable is set.
+          BROWSER_BACKEND: ${{ vars.URL_RESOLVER_BROWSER_BACKEND }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          envsubst '${FRONTEND_IMAGE} ${BACKEND_IMAGE} ${TRAFFIC_BLOCK} ${LANGFUSE_PUBLIC_KEY} ${LANGFUSE_SECRET_KEY} ${LANGFUSE_TRACING_ENVIRONMENT} ${DATABASE_URL} ${GCS_ARTIFACT_BUCKET} ${SERVICE_ACCOUNT_EMAIL} ${GC_PROJECT_ID} ${COFACTS_API_URL}' < service.template.yaml > service.yaml
-          cat service.yaml
+          # The allowlist is load-bearing: envsubst substitutes only the names
+          # listed here and passes every other ${...} through verbatim, so a
+          # placeholder missing from this list reaches Cloud Run as literal text.
+          # Listed-but-unset names become the empty string, which is the safe
+          # default the template is written around.
+          envsubst '${FRONTEND_IMAGE} ${BACKEND_IMAGE} ${TRAFFIC_BLOCK} ${LANGFUSE_PUBLIC_KEY} ${LANGFUSE_SECRET_KEY} ${LANGFUSE_TRACING_ENVIRONMENT} ${DATABASE_URL} ${GCS_ARTIFACT_BUCKET} ${SERVICE_ACCOUNT_EMAIL} ${GC_PROJECT_ID} ${COFACTS_API_URL} ${BROWSER_BACKEND} ${CLOUDFLARE_ACCOUNT_ID} ${CLOUDFLARE_API_TOKEN}' < service.template.yaml > service.yaml
+          # Deliberately not dumping service.yaml here: envsubst has just inlined
+          # DATABASE_URL, the Langfuse secret key and the Cloudflare API token
+          # into it. `gcloud run services replace` reports its own errors.
 
       - name: Deploy to Cloud Run
         run: |

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,11 +39,13 @@ flowchart LR
   One-time setup: `pnpm install`, then `pnpm install:agent` (`uv sync`), plus
   `gcloud auth application-default login` for Vertex AI. Two env files: root `.env`
   (browser/BFF) and `adk/cofacts_ai/.env` (agent).
-- **Prod:** a single **Cloud Run** service with three containers — `ingress` (frontend/BFF),
-  `backend` (ADK), and `cloudsql-proxy` — defined by `service.template.yaml` and deployed by
-  `.github/workflows/deploy.yml`. Containers talk over `localhost`.
+- **Prod:** a single **Cloud Run** service with four containers — `ingress` (frontend/BFF),
+  `backend` (ADK), `cloudsql-proxy`, and `url-resolver` — defined by `service.template.yaml`
+  and deployed by `.github/workflows/deploy.yml`. Containers talk over `localhost`, which is
+  also what keeps the unauthenticated `url-resolver` gRPC endpoint off the network.
   → decisions: [Cloud Run multi-container deploy](decisions/20260303-cloud-run-multi-container-deploy.md),
-  [Postgres session persistence](decisions/20260506-postgres-session-persistence.md).
+  [Postgres session persistence](decisions/20260506-postgres-session-persistence.md),
+  [verifier page pre-fetch](decisions/20260722-url-resolver-verifier-prefetch.md).
 
 ## The ADK multi-agent system
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,9 @@ flowchart LR
   `backend` (ADK), `cloudsql-proxy`, and `url-resolver` — defined by `service.template.yaml`
   and deployed by `.github/workflows/deploy.yml`. Containers talk over `localhost`, which is
   also what keeps the unauthenticated `url-resolver` gRPC endpoint off the network.
+  `url-resolver`'s headless browser runs either inside its own container or on Cloudflare
+  Browser Rendering, selected by the `URL_RESOLVER_BROWSER_BACKEND` repo variable
+  (unset = in-container chromium).
   → decisions: [Cloud Run multi-container deploy](decisions/20260303-cloud-run-multi-container-deploy.md),
   [Postgres session persistence](decisions/20260506-postgres-session-persistence.md),
   [verifier page pre-fetch](decisions/20260722-url-resolver-verifier-prefetch.md).

--- a/service.template.yaml
+++ b/service.template.yaml
@@ -11,7 +11,7 @@ spec:
     metadata:
       annotations:
         run.googleapis.com/execution-environment: gen2
-        run.googleapis.com/container-dependencies: '{"ingress":["backend"],"backend":["cloudsql-proxy"]}'
+        run.googleapis.com/container-dependencies: '{"ingress":["backend"],"backend":["cloudsql-proxy","url-resolver"]}'
         autoscaling.knative.dev/minScale: "0"
         autoscaling.knative.dev/maxScale: "3"
     spec:
@@ -75,6 +75,11 @@ spec:
           value: "${GCS_ARTIFACT_BUCKET}"
         - name: COFACTS_API_URL
           value: "${COFACTS_API_URL}"
+        # url-resolver runs as a sidecar in this same instance (see below), so
+        # the verifier's page pre-fetch talks to it over localhost instead of
+        # the docker-compose service name the client defaults to.
+        - name: URL_RESOLVER_ADDRESS
+          value: "localhost:4000"
         startupProbe:
           tcpSocket:
             port: 8000
@@ -97,6 +102,43 @@ spec:
         startupProbe:
           tcpSocket:
             port: 5432
+          initialDelaySeconds: 2
+          timeoutSeconds: 5
+          periodSeconds: 10
+          failureThreshold: 3
+      # Headless-browser page fetcher behind the verifier's URL pre-fetch. It
+      # speaks insecure gRPC with no auth, so it is never exposed as its own
+      # service: as a sidecar it is reachable only over this instance's
+      # localhost, the same containment the docker-compose deployment gets from
+      # its private network (rumors-deploy `docker-compose.sample.yml`).
+      - name: url-resolver
+        # Public Docker Hub image, published by cofacts/url-resolver on release
+        # tags (`:latest`) and master pushes (`:dev`). Cloud Run caches public
+        # Docker Hub images for up to an hour, so a freshly pushed `:latest` can
+        # take that long to appear in a new revision.
+        image: docker.io/cofacts/url-resolver:latest
+        resources:
+          limits:
+            # Chromium is what sizes this container: one browser process tree
+            # plus up to SCRAPE_MAX_CONCURRENCY (default 3) live pages. Cloud
+            # Run terminates the whole instance when any single container
+            # exceeds its memory limit — which would kill an agent turn in
+            # flight — so this is sized with headroom over the ~150 MiB idle
+            # footprint rather than trimmed to it. If it still OOMs, lower
+            # SCRAPE_MAX_CONCURRENCY before raising the limit.
+            cpu: "1000m"
+            memory: "2048Mi"
+        env:
+        - name: PORT
+          value: "4000"
+        startupProbe:
+          # The gRPC server binds immediately; chromium launches in the
+          # background right after. A TCP probe therefore only proves the RPC
+          # endpoint is up, not that a browser is ready — the client already
+          # treats an unreachable/failing resolver as "no signal" and falls
+          # back to `url_context`, so that is the right amount of gating here.
+          tcpSocket:
+            port: 4000
           initialDelaySeconds: 2
           timeoutSeconds: 5
           periodSeconds: 10

--- a/service.template.yaml
+++ b/service.template.yaml
@@ -126,11 +126,32 @@ spec:
             # flight — so this is sized with headroom over the ~150 MiB idle
             # footprint rather than trimmed to it. If it still OOMs, lower
             # SCRAPE_MAX_CONCURRENCY before raising the limit.
+            #
+            # This sizing follows the *local* browser path even when
+            # BROWSER_BACKEND is `cloudflare` and no chromium ever starts here.
+            # The backend is a repo variable that can revert to local at any
+            # moment, and a container trimmed to the Cloudflare footprint would
+            # OOM the instance the moment someone flips it back. Trim these only
+            # once the local fallback is retired for good.
             cpu: "1000m"
             memory: "2048Mi"
         env:
         - name: PORT
           value: "4000"
+        # Where puppeteer's browser runs. Unset renders as "" here, which
+        # url-resolver reads as `local` (`process.env.BROWSER_BACKEND || 'local'`),
+        # so an unconfigured deploy keeps launching chromium inside this
+        # container. Set the URL_RESOLVER_BROWSER_BACKEND repo variable to
+        # `cloudflare` to move it to Cloudflare Browser Rendering instead; clear
+        # the variable to roll back.
+        - name: BROWSER_BACKEND
+          value: "${BROWSER_BACKEND}"
+        # Only read when BROWSER_BACKEND is `cloudflare`; inert otherwise. The
+        # token needs the account-level "Browser Rendering: Edit" scope.
+        - name: CLOUDFLARE_ACCOUNT_ID
+          value: "${CLOUDFLARE_ACCOUNT_ID}"
+        - name: CLOUDFLARE_API_TOKEN
+          value: "${CLOUDFLARE_API_TOKEN}"
         startupProbe:
           # The gRPC server binds immediately; chromium launches in the
           # background right after. A TCP probe therefore only proves the RPC


### PR DESCRIPTION
Stacked on #118 — that PR adds the url-resolver client, this one gives it something to talk to on Cloud Run. Base will need retargeting to `master` once #118 merges.

## Problem

`URL_RESOLVER_ADDRESS` defaults to `url-resolver:4000`, a docker-compose service name that does not resolve on Cloud Run. Deployed as-is, the verifier's page pre-fetch would take the `RESOLVER_UNAVAILABLE` path on every turn and quietly fall back to `url_context`-only — exactly the behaviour #118 exists to replace, with no loud failure to notice it by.

## Change

A fourth container in `service.template.yaml`, mirroring how rumors-deploy's `docker-compose.sample.yml` runs it:

| | |
|---|---|
| image | `docker.io/cofacts/url-resolver:latest` (public Docker Hub, [supported by Cloud Run](https://docs.cloud.google.com/run/docs/deploying); cached up to an hour) |
| port | 4000, `PORT=4000` |
| resources | 1 vCPU / 2048 MiB |
| probe | TCP on 4000 |

Plus: `backend` gains `URL_RESOLVER_ADDRESS=localhost:4000` and a `container-dependencies` entry on `url-resolver`, and `docs/index.md` now describes four containers instead of three.

**Containment.** url-resolver is insecure gRPC with no auth. As a sidecar it is reachable only over the instance's localhost — the same property the compose deployment gets from its private network, and the reason it is not a separate Cloud Run service.

**Sizing.** 2 GiB is deliberate headroom, not a measured requirement: Cloud Run terminates the *whole instance* when any single container exceeds its memory limit, which on a 900 s request timeout means killing an agent turn in flight. Idle footprint measured at ~150 MiB (below); `SCRAPE_MAX_CONCURRENCY` (default 3) is the knob to lower before raising this limit.

Instance totals go from 2.5 vCPU / 3.25 GiB to 3.5 vCPU / 5.25 GiB.

## Verification

**Deployed.** Revision reached Ready with all four containers and the new totals — so Cloud Run accepted the fractional CPU sum, pulled the Docker Hub image, and the sidecar passed its startup probe. Preview serves HTTP 200. CI green.

Before that, locally: rendered `service.template.yaml` through the workflow's `envsubst` substitution and parsed the result (valid YAML, every `container-dependencies` reference resolves to a real container name), then ran the published image under a 1 vCPU / 1 GiB container limit:

```
gRPC server listening on 4000
Browser launched successfully.
```

8 chromium processes up, 153 MiB resident at idle. An end-to-end scrape could not be exercised in that sandbox — egress only goes through a TLS-intercepting proxy, so fetches fail at `node-fetch` before reaching puppeteer.

## Open risk: local puppeteer on Cloud Run

**Not yet confirmed working on Cloud Run**, and the deploy passing is not evidence either way. Chromium launches at module load and logs `Browser launched successfully.`; on failure it logs to Rollbar (disabled — no token configured) and leaves the gRPC server up. The startup probe is TCP, so it passes in both cases. A chromium that cannot start would surface only as `UNKNOWN_SCRAPE_ERROR` on every resolve, which the client buckets as "no signal" and degrades past silently.

Confirming it needs the sidecar's runtime log:

```
gcloud logging read \
  'resource.type=cloud_run_revision AND resource.labels.service_name=cofacts-ai
   AND labels."run.googleapis.com/container_name"=url-resolver' \
  --limit 50 --region asia-east1
```

The second risk is CPU throttling: the browser is one long-lived process reused across requests and frozen between them. `scrape.js` relaunches on `disconnected`, so a dropped CDP connection should self-heal, but the first affected request still fails.

If either bites, url-resolver already ships a Cloudflare Browser Rendering backend (`BROWSER_BACKEND=cloudflare` + `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN`) that moves chromium off the instance. Switching is env-only; not wired up here.